### PR TITLE
chore(deps-dev): upgrade eslint-plugin-ava to ^8

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "codecov": "^3.0.0",
     "eslint": "^6.0.0",
     "eslint-config-standard": "^13.0.0",
-    "eslint-plugin-ava": "^7.0.0",
+    "eslint-plugin-ava": "^8.0.0",
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-node": "^9.0.1",
     "eslint-plugin-promise": "^4.0.1",

--- a/test/cli.js
+++ b/test/cli.js
@@ -79,7 +79,7 @@ test('CLI argument: --protocol with a corresponding --protocol-name', t => {
 
 test('CLI argument: --protocol without a corresponding --protocol-name', t => {
   const args = cli.parseArgs(['--protocol=foo'])
-  t.deepEqual(args.protocols, undefined, 'no protocols have been fully defined')
+  t.is(args.protocols, undefined, 'no protocols have been fully defined')
 })
 
 test('CLI argument: multiple --protocol/--protocol-name argument pairs', t => {


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron/electron-packager/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The testsuite passes successfully on my local machine.

**Summarize your changes:**

New major version of `eslint-plugin-ava`, only one thing needed fixing.