### PR TITLE
chore(deps-dev): upgrade eslint-config-standard to ^14

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "buffer-equal": "^1.0.0",
     "codecov": "^3.0.0",
     "eslint": "^6.0.0",
-    "eslint-config-standard": "^13.0.0",
+    "eslint-config-standard": "^14.0.0",
     "eslint-plugin-ava": "^8.0.0",
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-node": "^9.0.1",

--- a/test/infer.js
+++ b/test/infer.js
@@ -46,7 +46,7 @@ async function inferMissingVersionTest (t, opts) {
 
   await getMetadataFromPackageJSON([], opts, opts.dir)
   const packageJSON = await fs.readJson(path.join(opts.dir, 'package.json'))
-  t.is(opts.electronVersion, packageJSON.devDependencies['electron'], 'The version should be inferred from installed electron module version')
+  t.is(opts.electronVersion, packageJSON.devDependencies.electron, 'The version should be inferred from installed electron module version')
 }
 
 async function testInferWin32metadata (t, opts, expected, assertionMessage) {

--- a/test/win32.js
+++ b/test/win32.js
@@ -131,7 +131,7 @@ function setCompanyNameTest (companyName) {
   return generateVersionStringTest('version-string',
                                    opts,
                                    { CompanyName: companyName },
-                                   `Company name should match win32metadata value`)
+                                   'Company name should match win32metadata value')
 }
 
 test('better error message when wine is not found', (t) => {


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron/electron-packager/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Pre-emptive upgrade.