### PR TITLE
fix: ensure that CFBundleExecutable and friends are correct for helper apps

### DIFF
--- a/src/mac.js
+++ b/src/mac.js
@@ -110,11 +110,15 @@ class MacApp extends App {
     })
   }
 
-  updateHelperPlist (base, suffix) {
+  updateHelperPlist (base, suffix, identifierIgnoresSuffix) {
     let helperSuffix, identifier, name
     if (suffix) {
       helperSuffix = `Helper ${suffix}`
-      identifier = `${this.helperBundleIdentifier}.${suffix}`
+      if (identifierIgnoresSuffix) {
+        identifier = this.helperBundleIdentifier
+      } else {
+        identifier = `${this.helperBundleIdentifier}.${suffix}`
+      }
       name = `${this.appName} ${helperSuffix}`
     } else {
       helperSuffix = 'Helper'
@@ -162,9 +166,9 @@ class MacApp extends App {
     ]
 
     const possiblePlists = [
-      [this.ehPlistFilename('Electron Helper (Renderer).app'), 'helperPlist'],
-      [this.ehPlistFilename('Electron Helper (Plugin).app'), 'helperPlist'],
-      [this.ehPlistFilename('Electron Helper (GPU).app'), 'helperPlist'],
+      [this.ehPlistFilename('Electron Helper (Renderer).app'), 'helperRendererPlist'],
+      [this.ehPlistFilename('Electron Helper (Plugin).app'), 'helperPluginPlist'],
+      [this.ehPlistFilename('Electron Helper (GPU).app'), 'helperGPUPlist'],
       [this.ehPlistFilename('Electron Helper EH.app'), 'helperEHPlist'],
       [this.ehPlistFilename('Electron Helper NP.app'), 'helperNPPlist'],
       [this.helperPlistFilename(this.loginHelperPath), 'loginHelperPlist']
@@ -184,11 +188,16 @@ class MacApp extends App {
     await this.extendAppPlist(this.opts.extendInfo)
     this.appPlist = this.updatePlist(this.appPlist, this.executableName, appBundleIdentifier, this.appName)
     this.helperPlist = this.updateHelperPlist(this.helperPlist)
-    if (this.helperEHPlist) {
-      this.helperEHPlist = this.updateHelperPlist(this.helperEHPlist, 'EH')
-    }
-    if (this.helperNPPlist) {
-      this.helperNPPlist = this.updateHelperPlist(this.helperNPPlist, 'NP')
+    const updateIfExists = [
+      ['helperRendererPlist', '(Renderer)', true],
+      ['helperPluginPlist', '(Plugin)', true],
+      ['helperGPUPlist', '(GPU)', true],
+      ['helperEHPlist', 'EH'],
+      ['helperNPPlist', 'NP']
+    ]
+    for (const [plistKey, ...suffixArgs] of updateIfExists) {
+      if (!this[plistKey]) continue
+      this[plistKey] = this.updateHelperPlist(this[plistKey], ...suffixArgs)
     }
 
     if (this.loginHelperPlist) {

--- a/test/darwin.js
+++ b/test/darwin.js
@@ -182,17 +182,17 @@ async function appHelpersBundleElectron6Test (t, opts) {
   assertCFBundleIdentifierValue(t, helperObj, helperBundleIdentifier, 'CFBundleIdentifier should reflect opts.helperBundleId, opts.appBundleId or fallback to default in helper app')
 
   const helperPluginObj = await util.parsePlist(t, path.join(frameworksPath, `${opts.name} Helper (Plugin).app`))
-  assertPlistStringValue(t, helperPluginObj, 'CFBundleName', `${opts.name} (Plugin)`, 'CFBundleName should reflect opts.name in helper app')
+  assertPlistStringValue(t, helperPluginObj, 'CFBundleName', `${opts.name} Helper (Plugin)`, 'CFBundleName should reflect opts.name in helper app')
   assertPlistStringValue(t, helperPluginObj, 'CFBundleExecutable', `${opts.name} Helper (Plugin)`, 'CFBundleExecutable should reflect opts.name in helper app')
   assertCFBundleIdentifierValue(t, helperPluginObj, helperBundleIdentifier, 'CFBundleIdentifier should reflect opts.helperBundleId, opts.appBundleId or fallback to default in helper app')
 
   const helperRendererObj = await util.parsePlist(t, path.join(frameworksPath, `${opts.name} Helper (Renderer).app`))
-  assertPlistStringValue(t, helperRendererObj, 'CFBundleName', `${opts.name} (Renderer)`, 'CFBundleName should reflect opts.name in helper app')
+  assertPlistStringValue(t, helperRendererObj, 'CFBundleName', `${opts.name} Helper (Renderer)`, 'CFBundleName should reflect opts.name in helper app')
   assertPlistStringValue(t, helperRendererObj, 'CFBundleExecutable', `${opts.name} Helper (Renderer)`, 'CFBundleExecutable should reflect opts.name in helper app')
   assertCFBundleIdentifierValue(t, helperRendererObj, helperBundleIdentifier, 'CFBundleIdentifier should reflect opts.helperBundleId, opts.appBundleId or fallback to default in helper app')
 
   const helperGPUObj = await util.parsePlist(t, path.join(frameworksPath, `${opts.name} Helper (GPU).app`))
-  assertPlistStringValue(t, helperGPUObj, 'CFBundleName', `${opts.name} (GPU)`, 'CFBundleName should reflect opts.name in helper app')
+  assertPlistStringValue(t, helperGPUObj, 'CFBundleName', `${opts.name} Helper (GPU)`, 'CFBundleName should reflect opts.name in helper app')
   assertPlistStringValue(t, helperGPUObj, 'CFBundleExecutable', `${opts.name} Helper (GPU)`, 'CFBundleExecutable should reflect opts.name in helper app')
   assertCFBundleIdentifierValue(t, helperGPUObj, helperBundleIdentifier, 'CFBundleIdentifier should reflect opts.helperBundleId, opts.appBundleId or fallback to default in helper app')
 }

--- a/test/darwin.js
+++ b/test/darwin.js
@@ -182,15 +182,18 @@ async function appHelpersBundleElectron6Test (t, opts) {
   assertCFBundleIdentifierValue(t, helperObj, helperBundleIdentifier, 'CFBundleIdentifier should reflect opts.helperBundleId, opts.appBundleId or fallback to default in helper app')
 
   const helperPluginObj = await util.parsePlist(t, path.join(frameworksPath, `${opts.name} Helper (Plugin).app`))
-  assertPlistStringValue(t, helperPluginObj, 'CFBundleName', opts.name, 'CFBundleName should reflect opts.name in helper app')
+  assertPlistStringValue(t, helperPluginObj, 'CFBundleName', `${opts.name} (Plugin)`, 'CFBundleName should reflect opts.name in helper app')
+  assertPlistStringValue(t, helperPluginObj, 'CFBundleExecutable', `${opts.name} Helper (Plugin)`, 'CFBundleExecutable should reflect opts.name in helper app')
   assertCFBundleIdentifierValue(t, helperPluginObj, helperBundleIdentifier, 'CFBundleIdentifier should reflect opts.helperBundleId, opts.appBundleId or fallback to default in helper app')
 
   const helperRendererObj = await util.parsePlist(t, path.join(frameworksPath, `${opts.name} Helper (Renderer).app`))
-  assertPlistStringValue(t, helperRendererObj, 'CFBundleName', opts.name, 'CFBundleName should reflect opts.name in helper app')
+  assertPlistStringValue(t, helperRendererObj, 'CFBundleName', `${opts.name} (Renderer)`, 'CFBundleName should reflect opts.name in helper app')
+  assertPlistStringValue(t, helperRendererObj, 'CFBundleExecutable', `${opts.name} Helper (Renderer)`, 'CFBundleExecutable should reflect opts.name in helper app')
   assertCFBundleIdentifierValue(t, helperRendererObj, helperBundleIdentifier, 'CFBundleIdentifier should reflect opts.helperBundleId, opts.appBundleId or fallback to default in helper app')
 
   const helperGPUObj = await util.parsePlist(t, path.join(frameworksPath, `${opts.name} Helper (GPU).app`))
-  assertPlistStringValue(t, helperGPUObj, 'CFBundleName', opts.name, 'CFBundleName should reflect opts.name in helper app')
+  assertPlistStringValue(t, helperGPUObj, 'CFBundleName', `${opts.name} (GPU)`, 'CFBundleName should reflect opts.name in helper app')
+  assertPlistStringValue(t, helperGPUObj, 'CFBundleExecutable', `${opts.name} Helper (GPU)`, 'CFBundleExecutable should reflect opts.name in helper app')
   assertCFBundleIdentifierValue(t, helperGPUObj, helperBundleIdentifier, 'CFBundleIdentifier should reflect opts.helperBundleId, opts.appBundleId or fallback to default in helper app')
 }
 


### PR DESCRIPTION
The `CFBundleExecutable` value was wrong as we were overwriting `this.helperPlist` for every helper.  Now we don't and now the values are correct.  There are even tests and stuff

Fixes #1045.