### PR TITLE
fix: send the properly formatted options from the CLI to electron-osx-sign

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -67,6 +67,9 @@ module.exports = {
     if (args.osxSign === 'true') {
       warning('--osx-sign does not take any arguments, it only has sub-properties (see --help)')
       args.osxSign = true
+    } else if (typeof args.osxSign === 'object' && !Array.isArray(args.osxSign)) {
+      // Keep kebab case of sub properties
+      args.osxSign = args['osx-sign']
     }
 
     if (args.osxNotarize) {

--- a/test/cli.js
+++ b/test/cli.js
@@ -37,6 +37,17 @@ test('CLI argument: --osx-sign=true', t => {
   t.true(args.osxSign)
 })
 
+test('CLI argument: --osx-sign is object', t => {
+  const args = cli.parseArgs([
+    '--osx-sign.identity=identity',
+    '--osx-sign.entitlements-inherit=path',
+    '--osx-sign.hardenedRuntime'
+  ])
+  t.is(args.osxSign.identity, 'identity')
+  t.is(args.osxSign['entitlements-inherit'], 'path')
+  t.true(args.osxSign.hardenedRuntime)
+})
+
 test('CLI argument: --osx-notarize=true', t => {
   const args = cli.parseArgs(['--osx-notarize=true'])
   t.falsy(args.osxNotarize, '')


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [x] I have read the [contribution documentation](https://github.com/electron/electron-packager/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Fix osx-sign can't get correctly sub properties, just use `osx-sign` arg instead of `osxSign`.

For `yargs-parser`, use camel case of args is meaning the subprops will be also converted to camel case, but it will break the [`osx-sign`](https://github.com/electron/electron-osx-sign/blob/master/sign.js#L307) usage like `entitlements-inherit`.