### PR TITLE
feat: add usageDescription option for darwin/mas targets

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,10 @@
 
 [Unreleased]: https://github.com/electron/electron-packager/compare/v14.0.6...master
 
+### Added
+
+* (darwin/mas only) `usageDescription` option
+
 ## [14.0.6] - 2019-09-09
 
 [14.0.6]: https://github.com/electron/electron-packager/compare/v14.0.5...v14.0.6

--- a/docs/api.md
+++ b/docs/api.md
@@ -474,7 +474,7 @@ Example:
 ```javascript
 {
   usageDescription: {
-    Camera: "Needed for video calls",
+    Camera: 'Needed for video calls',
     Microphone: 'Needed for voice calls'
   }
 }

--- a/docs/api.md
+++ b/docs/api.md
@@ -458,6 +458,8 @@ Each *Object* is required to have the following properties:
 
 ##### `usageDescription`
 
+*Object*
+
 Human-readable descriptions of how the Electron app uses certain macOS features. These are displayed
 in the App Store. A non-exhaustive list of available properties:
 
@@ -466,6 +468,17 @@ in the App Store. A non-exhaustive list of available properties:
 
 Valid properties are the [Cocoa keys for MacOS](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html)
 of the pattern `NS(.*)UsageDescription`, where the captured group is the key to use.
+
+Example:
+
+```javascript
+{
+  usageDescription: {
+    Camera: "Needed for video calls",
+    Microphone: 'Needed for voice calls'
+  }
+}
+```
 
 #### Windows targets only
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -456,6 +456,17 @@ Each *Object* is required to have the following properties:
   example, specifying `myapp` would cause URLs such as `myapp://path` to be opened with the app.
   Maps to the `CFBundleURLSchemes` metadata property.
 
+##### `usageDescription`
+
+Human-readable descriptions of how the Electron app uses certain macOS features. These are displayed
+in the App Store. A non-exhaustive list of available properties:
+
+* `Camera` - required for media access API usage in macOS Catalina
+* `Microphone` - required for media access API usage in macOS Catalina
+
+Valid properties are the [Cocoa keys for MacOS](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html)
+of the pattern `NS(.*)UsageDescription`, where the captured group is the key to use.
+
 #### Windows targets only
 
 ##### `win32metadata`

--- a/src/mac.js
+++ b/src/mac.js
@@ -36,6 +36,10 @@ class MacApp extends App {
     return this.opts.darwinDarkModeSupport
   }
 
+  get usageDescription () {
+    return this.opts.usageDescription
+  }
+
   get protocols () {
     return this.opts.protocols.map((protocol) => {
       return {
@@ -229,6 +233,12 @@ class MacApp extends App {
 
     if (this.enableDarkMode) {
       this.appPlist.NSRequiresAquaSystemAppearance = false
+    }
+
+    if (this.usageDescription) {
+      for (const [type, description] of Object.entries(this.usageDescription)) {
+        this.appPlist[`NS${type}UsageDescription`] = description
+      }
     }
 
     await Promise.all(plists.map(([filename, varName]) =>

--- a/test/darwin.js
+++ b/test/darwin.js
@@ -406,6 +406,13 @@ if (!(process.env.CI && process.platform === 'win32')) {
     t.is(info.NSHumanReadableCopyright, copyright, 'NSHumanReadableCopyright should reflect opts.appCopyright')
   }))
 
+  test.serial('usageDescription fills the correct keys', darwinTest(async (t, baseOpts) => {
+    const description = 'I am a Karaoke app'
+    const opts = { ...baseOpts, usageDescription: { Microphone: description } }
+    const info = await packageAndParseInfoPlist(t, opts)
+    t.is(info.NSMicrophoneUsageDescription, description, 'NSMicrophoneUsageDescription should reflect opts.usageDescription.Microphone')
+  }))
+
   test.serial('app named Electron packaged successfully', darwinTest(async (t, baseOpts) => {
     const opts = { ...baseOpts, name: 'Electron' }
     const finalPath = (await packager(opts))[0]

--- a/usage.txt
+++ b/usage.txt
@@ -98,6 +98,10 @@ protocol           URL protocol scheme to register the app as an opener of.
                    URLs such as `myapp://path`. This argument requires a `--protocol-name`
                    argument to also be specified.
 protocol-name      Descriptive name of URL protocol scheme specified via `--protocol`
+usage-description  Human-readable descriptions of how the app uses certain macOS features. Displayed
+                   in the App Store. A non-exhaustive list of properties supported:
+                   - Camera
+                   - Microphone
 
 * win32 target platform only *
 


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron/electron-packager/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Adds a convenience option to set usage descriptions for the macOS store, on `darwin`/`mas` targets.

Reference: https://github.com/electron/electron/pull/19871#pullrequestreview-278011263