### PR TITLE
Update electron-notarize to 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "asar": "^2.0.1",
     "cross-zip": "^2.1.5",
     "debug": "^4.0.1",
-    "electron-notarize": "^0.1.1",
+    "electron-notarize": "^0.2.0",
     "electron-osx-sign": "^0.4.11",
     "fs-extra": "^8.1.0",
     "galactus": "^0.2.1",


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [X] I have read the [contribution documentation](https://github.com/electron/electron-packager/blob/master/CONTRIBUTING.md) for this project.
* [X] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [X] The changes are appropriately documented (if applicable).
* [X] The changes have sufficient test coverage (if applicable).
* [ ] The testsuite passes successfully on my local machine (if applicable).

Test suite does not pass on my machine, but I think that's because it's macOS Catalina which can't run 64-bit apps. The same tests fail on master for me.

**Summarize your changes:**

I updated the electron-notarize package to 0.2.0 to bring in a fix for notarization timeouts that are plaguing me and many others.