### PR TITLE
Upgrade rcedit to support 64-bit

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "junk": "^3.1.0",
     "parse-author": "^2.0.0",
     "plist": "^3.0.0",
-    "rcedit": "^2.0.0",
+    "rcedit": "^2.1.0",
     "resolve": "^1.1.6",
     "sanitize-filename": "^1.6.0",
     "semver": "^6.0.0",


### PR DESCRIPTION
* [ X ] I have read the [contribution documentation](https://github.com/electron/electron-packager/blob/master/CONTRIBUTING.md) for this project.
* [ X ] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.

This simply upgrades rcedit package to 2.1.0 or above, which now supports 64-bit rcedit.

