### PR TITLE
fix: always initialize proxy support when running the CLI

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -2,6 +2,7 @@
 
 const { hostInfo, warning } = require('./common')
 const fs = require('fs-extra')
+const { initializeProxy } = require('@electron/get')
 const packager = require('..')
 const path = require('path')
 const yargs = require('yargs-parser')
@@ -116,6 +117,8 @@ module.exports = {
     } else if (!args.dir) {
       await printUsageAndExit(true)
     }
+
+    initializeProxy()
 
     try {
       const appPaths = await packager(args)


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron/electron-packager/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.

**Summarize your changes:**

Don't expect users to set the environment variable `ELECTRON_GET_USE_PROXY=1` if they need to use a proxy.