### PR TITLE
test(macOS): disable win32 target testing

### DIFF
--- a/test/_setup.js
+++ b/test/_setup.js
@@ -13,6 +13,12 @@ const targets = require('../src/targets')
 
 childProcess.exec = promisify(childProcess.exec)
 
+if (process.env.CI && process.platform === 'darwin') {
+  // stub out rcedit due to Wine not being able to be configured in CI
+  require('rcedit')
+  require.cache[path.resolve(__dirname, '../node_modules/rcedit/lib/rcedit.js')].exports = function () {}
+}
+
 function fixtureSubdir (subdir) {
   return path.join(__dirname, 'fixtures', subdir)
 }

--- a/test/ci/before_install.sh
+++ b/test/ci/before_install.sh
@@ -11,6 +11,6 @@ case "$(uname -s)" in
     "$(dirname $0)"/codesign/import-testing-cert-ci.sh
     brew cask install xquartz wine-stable
     # Setup ~/.wine by running a command
-    wine hostname
+    WINEDEBUG=warn+all wine hostname
     ;;
 esac

--- a/test/ci/before_install.sh
+++ b/test/ci/before_install.sh
@@ -11,6 +11,6 @@ case "$(uname -s)" in
     "$(dirname $0)"/codesign/import-testing-cert-ci.sh
     brew cask install xquartz wine-stable
     # Setup ~/.wine by running a command
-    WINEDEBUG=warn+all wine hostname
+    wineconsole hostname
     ;;
 esac

--- a/test/ci/before_install.sh
+++ b/test/ci/before_install.sh
@@ -9,7 +9,7 @@ case "$(uname -s)" in
     ;;
   "Darwin")
     "$(dirname $0)"/codesign/import-testing-cert-ci.sh
-    brew cask install wine-stable
+    brew cask install xquartz wine-stable
     # Setup ~/.wine by running a command
     wine hostname
     ;;

--- a/test/ci/before_install.sh
+++ b/test/ci/before_install.sh
@@ -9,7 +9,7 @@ case "$(uname -s)" in
     ;;
   "Darwin")
     "$(dirname $0)"/codesign/import-testing-cert-ci.sh
-    brew install wine
+    brew cask install wine-stable
     # Setup ~/.wine by running a command
     wine hostname
     ;;

--- a/test/ci/before_install.sh
+++ b/test/ci/before_install.sh
@@ -9,8 +9,5 @@ case "$(uname -s)" in
     ;;
   "Darwin")
     "$(dirname $0)"/codesign/import-testing-cert-ci.sh
-    brew cask install xquartz wine-stable
-    # Setup ~/.wine by running a command
-    wineconsole hostname
     ;;
 esac

--- a/test/win32.js
+++ b/test/win32.js
@@ -182,28 +182,30 @@ function win32Test (extraOpts, executableBasename, executableMessage) {
   })
 }
 
-test.serial('win32 executable name is based on sanitized app name', win32Test(
-  { name: '@username/package-name' },
-  '@username-package-name',
-  'The sanitized EXE filename should exist'
-))
+if (!(process.env.CI && process.platform === 'darwin')) {
+  test.serial('win32 executable name is based on sanitized app name', win32Test(
+    { name: '@username/package-name' },
+    '@username-package-name',
+    'The sanitized EXE filename should exist'
+  ))
 
-test.serial('win32 executable name uses executableName when available', win32Test(
-  { name: 'PackageName', executableName: 'my-package' },
-  'my-package',
-  'the executableName-based filename should exist'
-))
+  test.serial('win32 executable name uses executableName when available', win32Test(
+    { name: 'PackageName', executableName: 'my-package' },
+    'my-package',
+    'the executableName-based filename should exist'
+  ))
 
-test.serial('win32 icon set', win32Test(
-  { executableName: 'iconTest', arch: 'ia32', icon: path.join(__dirname, 'fixtures', 'monochrome') },
-  'iconTest',
-  'the Electron executable should exist'
-))
+  test.serial('win32 icon set', win32Test(
+    { executableName: 'iconTest', arch: 'ia32', icon: path.join(__dirname, 'fixtures', 'monochrome') },
+    'iconTest',
+    'the Electron executable should exist'
+  ))
 
-test('win32 build version sets FileVersion test', setFileVersionTest('2.3.4.5'))
-test('win32 app version sets ProductVersion test', setProductVersionTest('5.4.3.2'))
-test('win32 app copyright sets LegalCopyright test', setCopyrightTest('Copyright Bar'))
-test('win32 set LegalCopyright and CompanyName test', setCopyrightAndCompanyNameTest('Copyright Bar', 'MyCompany LLC'))
-test('win32 set CompanyName test', setCompanyNameTest('MyCompany LLC'))
-test('win32 set requested-execution-level test', setRequestedExecutionLevelTest('asInvoker'))
-test('win32 set application-manifest test', setApplicationManifestTest('/path/to/manifest.xml'))
+  test('win32 build version sets FileVersion test', setFileVersionTest('2.3.4.5'))
+  test('win32 app version sets ProductVersion test', setProductVersionTest('5.4.3.2'))
+  test('win32 app copyright sets LegalCopyright test', setCopyrightTest('Copyright Bar'))
+  test('win32 set LegalCopyright and CompanyName test', setCopyrightAndCompanyNameTest('Copyright Bar', 'MyCompany LLC'))
+  test('win32 set CompanyName test', setCompanyNameTest('MyCompany LLC'))
+  test('win32 set requested-execution-level test', setRequestedExecutionLevelTest('asInvoker'))
+  test('win32 set application-manifest test', setApplicationManifestTest('/path/to/manifest.xml'))
+}


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron/electron-packager/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes have sufficient test coverage (if applicable).

**Summarize your changes:**

[`wine` was removed from Homebrew-core](https://github.com/Homebrew/homebrew-core/pull/46556) due to macOS 10.15 incompatibility. Trying to install it from Homebrew casks results in CI hanging. So, disable win32 tests on macOS CI until the situation is resolved.