### PR TITLE
fix(infer): make the error message clearer when infer cannot find a package.json file

### DIFF
--- a/src/infer.js
+++ b/src/infer.js
@@ -22,9 +22,13 @@ function errorMessageForProperty (prop) {
       hash = 'electronversion'
       propDescription = 'Electron version'
       break
+    case 'version':
+      hash = 'appversion'
+      propDescription = 'application version'
+      break
     default:
       hash = ''
-      propDescription = '[Unknown Property]'
+      propDescription = `[Unknown Property (${prop})]`
   }
 
   return `Unable to determine ${propDescription}. Please specify an ${propDescription}\n\n` +

--- a/test/infer.js
+++ b/test/infer.js
@@ -88,6 +88,7 @@ test('infer win32metadata', util.testSinglePlatform(async (t, opts) => {
 }))
 test('do not infer win32metadata if it already exists', util.testSinglePlatform(async (t, opts) => {
   opts.win32metadata = { CompanyName: 'Existing' }
+  opts.appVersion = '1.0.0'
   const expected = { ...opts.win32metadata }
 
   return testInferWin32metadata(t, opts, expected, 'win32metadata did not update with package.json values')


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron/electron-packager/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Also, handle a missing inferred app version better.

Fixes #1072.