### PR TITLE
test: add nightly canary

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           repository: electron/electron-quick-start
           ref: refs/heads/master
-          path: {{ env.HOME }}/electron-quick-start
+          path: ${{ env.HOME }}/electron-quick-start
       - name: Use Node.js 8.x
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -16,16 +16,19 @@ jobs:
         with:
           repository: electron/electron-quick-start
           ref: refs/heads/master
+          path: {{ env.HOME }}/electron-quick-start
       - name: Use Node.js 8.x
         uses: actions/setup-node@v1
         with:
           node-version: 8.x
       - name: Replace electron with electron-nightly
         run: |
+          cd $HOME/electron-quick-start
           npm uninstall --save-dev electron
           npm install --save-dev electron-nightly@latest
-      - name: Install
-        run: npm install --save-dev electron-packager
+        shell: bash
+      - name: Install Electron Packager
+        run: npm install --save-dev electron-packager@electron/electron-packager
       - name: Package
-        run: node_modules/.bin/electron-packager .
+        run: node_modules/.bin/electron-packager $HOME/electron-quick-start
         shell: bash

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           repository: electron/electron-quick-start
           ref: refs/heads/master
-          path: ${{ env.HOME }}/electron-quick-start
+          path: electron-quick-start
       - name: Use Node.js 8.x
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -35,4 +35,3 @@ jobs:
         run: |
           cd ../electron-quick-start
           node_modules/.bin/electron-packager . --arch=all
-        shell: bash

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -1,4 +1,4 @@
-name: Canary
+name: electron-nightly Canary
 
 on:
   schedule:

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -1,0 +1,29 @@
+name: Canary
+
+on: [push]
+  # schedule:
+  #   - cron: '15 8 * * *'
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest, macOS-latest, ubuntu-latest]
+
+    steps:
+      - uses: actions/checkout@v1
+        with: electron/electron-quick-start
+      - name: Use Node.js 8.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 8.x
+      - name: Replace electron with electron-nightly
+        run: |
+          npm uninstall --save-dev electron
+          npm install --save-dev electron-nightly@latest
+      - name: Install
+        run: npm install --save-dev electron-packager
+      - name: Package
+        run: node_modules/.bin/electron-packager .
+        shell: bash

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -23,12 +23,12 @@ jobs:
           node-version: 8.x
       - name: Replace electron with electron-nightly
         run: |
-          cd $HOME/electron-quick-start
+          cd $GITHUB_WORKSPACE/../electron-quick-start
           npm uninstall --save-dev electron
           npm install --save-dev electron-nightly@latest
         shell: bash
       - name: Install Electron Packager
         run: npm install --save-dev electron-packager@electron/electron-packager
       - name: Package
-        run: node_modules/.bin/electron-packager $HOME/electron-quick-start
+        run: node_modules/.bin/electron-packager $GITHUB_WORKSPACE/../electron-quick-start
         shell: bash

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -29,10 +29,10 @@ jobs:
         shell: bash
       - name: Install Electron Packager
         run: |
-          cd $GITHUB_WORKSPACE/../electron-quick-start
+          cd ../electron-quick-start
           npm install --save-dev electron-packager@electron/electron-packager
       - name: Package
         run: |
-          cd $GITHUB_WORKSPACE/../electron-quick-start
+          cd ../electron-quick-start
           node_modules/.bin/electron-packager . --arch=all
         shell: bash

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -13,7 +13,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v1
-        with: electron/electron-quick-start
+        with:
+          repository: electron/electron-quick-start
       - name: Use Node.js 8.x
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -1,8 +1,8 @@
 name: Canary
 
-on: [push]
-  # schedule:
-  #   - cron: '15 8 * * *'
+on:
+  schedule:
+    - cron: '15 8 * * *'
 
 jobs:
   build:

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -15,6 +15,7 @@ jobs:
       - uses: actions/checkout@v1
         with:
           repository: electron/electron-quick-start
+          ref: refs/heads/master
       - name: Use Node.js 8.x
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -28,7 +28,11 @@ jobs:
           npm install --save-dev electron-nightly@latest
         shell: bash
       - name: Install Electron Packager
-        run: npm install --save-dev electron-packager@electron/electron-packager
+        run: |
+          cd $GITHUB_WORKSPACE/../electron-quick-start
+          npm install --save-dev electron-packager@electron/electron-packager
       - name: Package
-        run: node_modules/.bin/electron-packager $GITHUB_WORKSPACE/../electron-quick-start
+        run: |
+          cd $GITHUB_WORKSPACE/../electron-quick-start
+          node_modules/.bin/electron-packager . --arch=all
         shell: bash


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron/electron-packager/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.

**Summarize your changes:**

This is a feature I brought up at the Electron Maintainers Summit in NYC. A canary runs daily (via GitHub Actions) that:

1. Checks out `electron-quick-start`
2. Replaces `electron` with `electron-nightly`
3. Uses Electron Packager from the `master` branch to build an Electron app for all platforms and arches

This is meant to find any strange problems in Electron nightlies when customizing and bundling apps.