### PR TITLE
unzip should preserve symbolic links on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,10 +27,10 @@
   "dependencies": {
     "@electron/get": "^1.6.0",
     "asar": "^2.0.1",
-    "cross-zip": "^2.1.5",
     "debug": "^4.0.1",
     "electron-notarize": "^0.2.0",
     "electron-osx-sign": "^0.4.11",
+    "extract-zip": "^1.6.7",
     "fs-extra": "^8.1.0",
     "galactus": "^0.2.1",
     "get-package-info": "^1.0.0",

--- a/src/unzip.js
+++ b/src/unzip.js
@@ -1,31 +1,10 @@
 'use strict'
 
-const os = require('os')
 const { promisify } = require('util')
-const { warning } = require('./common')
-const zip = require('cross-zip')
+const extract = require('extract-zip')
 
-const unzip = promisify(zip.unzip)
-
-/**
- * Detects Windows 7 via release number.
- *
- * This also detects Windows Server 2008 R2, but since we're using it to determine whether to check * for Powershell/.NET Framework, it's fine.
- */
-function probablyWindows7 () {
-  if (process.platform === 'win32') {
-    const [majorVersion, minorVersion] = os.release().split('.').map(Number)
-    return majorVersion === 6 && minorVersion === 1
-  }
-
-  return false
-}
+const unzip = promisify(extract)
 
 module.exports = async function extractElectronZip (zipPath, targetDir) {
-  if (probablyWindows7()) {
-    /* istanbul ignore next */
-    warning('Make sure that .NET Framework 4.5 or later and Powershell 3 or later are installed, otherwise extracting the Electron zip file will hang.')
-  }
-
-  return unzip(zipPath, targetDir)
+  return unzip(zipPath, { dir: targetDir })
 }

--- a/test/index.js
+++ b/test/index.js
@@ -10,6 +10,7 @@ require('./infer')
 require('./hooks')
 require('./prune')
 require('./targets')
+require('./unzip')
 require('./win32')
 
 if (process.platform !== 'win32') {

--- a/test/unzip.js
+++ b/test/unzip.js
@@ -1,0 +1,24 @@
+'use strict'
+
+const download = require('../src/download')
+const unzip = require('../src/unzip')
+const fs = require('fs-extra')
+const config = require('./config.json')
+const path = require('path')
+const os = require('os')
+const test = require('ava')
+
+for (const downloadOpts of download.createDownloadCombos({ electronVersion: config.version }, ['darwin', 'mas'], ['x64'])) {
+  test.serial(`unzip preserves symbolic links (${downloadOpts.platform})`, t => { return unzipPreserveSymbolicLinks(t, downloadOpts) })
+}
+
+async function unzipPreserveSymbolicLinks (t, downloadOpts) {
+  const zipPath = await download.downloadElectronZip(downloadOpts)
+  const tempPath = await fs.mkdtemp(path.join(os.tmpdir(), 'symlinktest-'))
+
+  await unzip(zipPath, tempPath)
+
+  const testSymlinkPath = path.join(tempPath, 'Electron.app/Contents/Frameworks/Electron Framework.framework/Libraries')
+  const stat = await fs.lstat(testSymlinkPath)
+  t.true(stat.isSymbolicLink(), 'extract symoblic links')
+}


### PR DESCRIPTION
Adding test which shows that `cross-zip` does not preserve symbolic links on windows. After this build fails I will add another commit which reverts https://github.com/electron/electron-packager/pull/984 to show that this worked before.

---

Fixing this is only the first step in enabling building macOS packages on windows.
The next problem is that `fs-extra` is using [`fs.stat` instead of `fs.lstat`](https://github.com/jprichardson/node-fs-extra/blob/2b97fe3e502ab5d5abd92f19d588bd1fc113c3f2/lib/util/stat.js#L31) which failes for symbolic links on windows. (I will open an issue there and see if this is intended or not.) So the package can not be moved:
https://github.com/electron/electron-packager/blob/2e974d1211020eb22ac75c21cc0966b9bfaac216/src/platform.js#L215
**EDIT**: Or maybe this is only an issue on my machines? Because all the `fs-extra` symlink tests are failing on my machine even when running as administrator... I will investigate more...