### PR TITLE
fix(win32): handle missing wine64 binaries in addition to wine

### DIFF
--- a/src/win32.js
+++ b/src/win32.js
@@ -7,11 +7,12 @@ const App = require('./platform')
 const common = require('./common')
 
 function updateWineMissingException (err) {
-  if (err && err.code === 'ENOENT' && err.syscall === 'spawn wine') {
-    err.message = 'Could not find "wine" on your system.\n\n' +
+  if (err && err.code === 'ENOENT' && ['spawn wine', 'spawn wine64'].includes(err.syscall)) {
+    const binary = err.syscall.split(' ')[1]
+    err.message = `Could not find "${binary}" on your system.\n\n` +
       'Wine is required to use the appCopyright, appVersion, buildVersion, icon, and \n' +
       'win32metadata parameters for Windows targets.\n\n' +
-      'Make sure that the "wine" executable is in your PATH.\n\n' +
+      `Make sure that the "${binary}" executable is in your PATH.\n\n` +
       'See https://github.com/electron/electron-packager#building-windows-apps-from-non-windows-platforms for details.'
   }
 

--- a/test/win32.js
+++ b/test/win32.js
@@ -134,17 +134,19 @@ function setCompanyNameTest (companyName) {
                                    'Company name should match win32metadata value')
 }
 
-test('better error message when wine is not found', (t) => {
-  let err = Error('spawn wine ENOENT')
-  err.code = 'ENOENT'
-  err.syscall = 'spawn wine'
+for (const wineBinary of ['wine', 'wine64']) {
+  test(`better error message when ${wineBinary} is not found`, t => {
+    let err = Error(`spawn ${wineBinary} ENOENT`)
+    err.code = 'ENOENT'
+    err.syscall = `spawn ${wineBinary}`
 
-  t.is(err.message, 'spawn wine ENOENT')
-  err = win32.updateWineMissingException(err)
-  t.not(err.message, 'spawn wine ENOENT')
-})
+    t.is(err.message, `spawn ${wineBinary} ENOENT`)
+    err = win32.updateWineMissingException(err)
+    t.not(err.message, `spawn ${wineBinary} ENOENT`)
+  })
+}
 
-test('error message unchanged when error not about wine', t => {
+test('error message unchanged when error not about wine/wine64', t => {
   let errNotEnoent = Error('unchanged')
   errNotEnoent.code = 'ESOMETHINGELSE'
   errNotEnoent.syscall = 'spawn wine'


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron/electron-packager/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

node-rcedit 2.1.0 added support for wine64. Since Packager rewrites the error message to be more human-readable, it needs to take into account the new binary name possibility.