### PR TITLE
fix: emit a warning if --osx-sign and a sub-property are specified in the CLI

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -68,9 +68,13 @@ module.exports = {
     if (args.osxSign === 'true') {
       warning('--osx-sign does not take any arguments, it only has sub-properties (see --help)')
       args.osxSign = true
-    } else if (typeof args.osxSign === 'object' && !Array.isArray(args.osxSign)) {
-      // Keep kebab case of sub properties
-      args.osxSign = args['osx-sign']
+    } else if (typeof args['osx-sign'] === 'object') {
+      if (Array.isArray(args['osx-sign'])) {
+        warning('Remove --osx-sign (the bare flag) from the command line, only specify sub-properties (see --help)')
+      } else {
+        // Keep kebab case of sub properties
+        args.osxSign = args['osx-sign']
+      }
     }
 
     if (args.osxNotarize) {

--- a/test/cli.js
+++ b/test/cli.js
@@ -2,6 +2,7 @@
 
 const cli = require('../src/cli')
 const test = require('ava')
+const util = require('./_util')
 
 test('CLI argument: --electron-version populates opts.electronVersion', t => {
   let args = cli.parseArgs([])
@@ -35,6 +36,12 @@ test('CLI argument: using --asar overrides other --asar.options', t => {
 test('CLI argument: --osx-sign=true', t => {
   const args = cli.parseArgs(['--osx-sign=true'])
   t.true(args.osxSign)
+})
+
+test('CLI argument: --osx-sign and --osx-sign subproperties should not be mixed', t => {
+  util.setupConsoleWarnSpy()
+  cli.parseArgs(['--osx-sign', '--osx-sign.identity=identity'])
+  util.assertWarning(t, 'WARNING: Remove --osx-sign (the bare flag) from the command line, only specify sub-properties (see --help)')
 })
 
 test('CLI argument: --osx-sign is object', t => {


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron/electron-packager/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Avoids issues like #1086.