### PR TITLE
fix: make symlink test robust to parallel packaging

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -32,7 +32,7 @@ class Packager {
   }
 
   async testSymlink (comboOpts, zipPath) {
-    const testPath = path.join(this.tempBase, 'symlink-test' + Math.random())
+    const testPath = path.join(this.tempBase, `symlink-test-${comboOpts.platform}-${comboOpts.arch}`)
     const testFile = path.join(testPath, 'test')
     const testLink = path.join(testPath, 'testlink')
 

--- a/src/index.js
+++ b/src/index.js
@@ -32,7 +32,7 @@ class Packager {
   }
 
   async testSymlink (comboOpts, zipPath) {
-    const testPath = path.join(this.tempBase, 'symlink-test')
+    const testPath = path.join(this.tempBase, 'symlink-test' + Math.random())
     const testFile = path.join(testPath, 'test')
     const testLink = path.join(testPath, 'testlink')
 


### PR DESCRIPTION
randomize testPath in symlink test to allow parallel compilation with the --all option

<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [x] I have read the [contribution documentation](https://github.com/electron/electron-packager/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [] The changes are appropriately documented (if applicable).
* [] The changes have sufficient test coverage (if applicable).
* [] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Hi, on my linux machine (8 cores), the -all option does not create mas and darwin packages:
```
$ uname -a
Linux AC-SV-611 5.3.0-24-generic #26-Ubuntu SMP Thu Nov 14 01:33:18 UTC 2019 x86_64 x86_64 x86_64 GNU/Linux
$ npx electron-packager --version
Electron Packager 14.1.1
Node v12.13.0
Host Operating system: linux 5.3.0-24-generic (x64)

$ npx electron-packager --all  --overwrite=true  compiled/build/ EduAnat2
Packaging app for platform win32 ia32 using electron v7.1.3
Packaging app for platform win32 x64 using electron v7.1.3
Packaging app for platform win32 arm64 using electron v7.1.3
Cannot create symlinks (on Windows hosts, it requires admin privileges); skipping darwin platform
Cannot create symlinks (on Windows hosts, it requires admin privileges); skipping mas platform
Packaging app for platform linux ia32 using electron v7.1.3
Packaging app for platform linux x64 using electron v7.1.3
Packaging app for platform linux armv7l using electron v7.1.3
Packaging app for platform linux arm64 using electron v7.1.3
Wrote new apps to:
/home/valette/git/eduAnat2/EduAnat2-linux-ia32
/home/valette/git/eduAnat2/EduAnat2-win32-ia32
/home/valette/git/eduAnat2/EduAnat2-linux-x64
/home/valette/git/eduAnat2/EduAnat2-win32-x64
/home/valette/git/eduAnat2/EduAnat2-linux-armv7l
/home/valette/git/eduAnat2/EduAnat2-linux-arm64
/home/valette/git/eduAnat2/EduAnat2-win32-arm64
```

whereas packaging for mas or darwin platforms one by one works:
```
npx electron-packager --platform=darwin  --overwrite=true  compiled/build/ EduAnat2
Packaging app for platform darwin x64 using electron v7.1.3
Wrote new app to /home/valette/git/eduAnat2/EduAnat2-darwin-x64
$ npx electron-packager --platform=mas  --overwrite=true  compiled/build/ EduAnat2
Packaging app for platform mas x64 using electron v7.1.3
WARNING: signing is required for mas builds. Provide the osx-sign option, or manually sign the app later.
Wrote new app to /home/valette/git/eduAnat2/EduAnat2-mas-x64
```

it seems that parallel building is the culprit : when testing for symlink creation, a single 'symlink-test' folder is created but this seems to fail when building in parallel. Randomizing the folder name fixes the issue. With the proposed fix:
```
$ npx electron-packager --all  --overwrite=true  compiled/build/ EduAnat2
Packaging app for platform linux ia32 using electron v7.1.3
Packaging app for platform win32 ia32 using electron v7.1.3
Packaging app for platform linux x64 using electron v7.1.3
Packaging app for platform win32 x64 using electron v7.1.3
Packaging app for platform win32 arm64 using electron v7.1.3
Packaging app for platform linux arm64 using electron v7.1.3
Packaging app for platform linux armv7l using electron v7.1.3
Packaging app for platform darwin x64 using electron v7.1.3
Packaging app for platform mas x64 using electron v7.1.3
WARNING: signing is required for mas builds. Provide the osx-sign option, or manually sign the app later.
Wrote new apps to:
/home/valette/git/eduAnat2/EduAnat2-linux-ia32
/home/valette/git/eduAnat2/EduAnat2-win32-ia32
/home/valette/git/eduAnat2/EduAnat2-darwin-x64
/home/valette/git/eduAnat2/EduAnat2-linux-x64
/home/valette/git/eduAnat2/EduAnat2-mas-x64
/home/valette/git/eduAnat2/EduAnat2-win32-x64
/home/valette/git/eduAnat2/EduAnat2-linux-armv7l
/home/valette/git/eduAnat2/EduAnat2-linux-arm64
/home/valette/git/eduAnat2/EduAnat2-win32-arm64
```



