### PR TITLE
fix: make relative paths work with `dir` option

### DIFF
--- a/src/mac.js
+++ b/src/mac.js
@@ -138,7 +138,7 @@ class MacApp extends App {
     }
 
     if (typeof propsOrFilename === 'string') {
-      const plist = await this.loadPlist(propsOrFilename)
+      const plist = await this.loadPlist(this.inputPath(propsOrFilename))
       return Object.assign(this.appPlist, plist)
     } else {
       return Object.assign(this.appPlist, propsOrFilename)

--- a/src/platform.js
+++ b/src/platform.js
@@ -81,6 +81,10 @@ class App {
     return this.relativeRename(this.electronBinaryDir, this.originalElectronName, this.newElectronName)
   }
 
+  inputPath (filePath) {
+    return path.resolve(this.opts.dir, filePath)
+  }
+
   /**
    * Performs the following initial operations for an app:
    * * Creates temporary directory
@@ -144,7 +148,7 @@ class App {
   async normalizeIconExtension (targetExt) {
     if (!this.opts.icon) throw new Error('No filename specified to normalizeIconExtension')
 
-    let iconFilename = this.opts.icon
+    let iconFilename = this.inputPath(this.opts.icon)
     const ext = path.extname(iconFilename)
     if (ext !== targetExt) {
       iconFilename = path.join(path.dirname(iconFilename), path.basename(iconFilename, ext) + targetExt)
@@ -203,7 +207,7 @@ class App {
     const extraResources = common.ensureArray(this.opts.extraResource)
 
     await Promise.all(extraResources.map(
-      resource => fs.copy(resource, path.resolve(this.stagingPath, this.resourcesDir, path.basename(resource)))
+      resource => fs.copy(this.inputPath(resource), path.resolve(this.stagingPath, this.resourcesDir, path.basename(resource)))
     ))
   }
 

--- a/test/basic.js
+++ b/test/basic.js
@@ -203,44 +203,50 @@ test.serial('deref symlink', util.testSinglePlatform(async (t, opts) => {
   await fs.remove(dest)
 }))
 
-async function createExtraResourceStringTest (t, opts, platform) {
+async function createExtraResourceStringTest (t, opts, platform, relative) {
   const extra1Base = 'data1.txt'
-  const extra1Path = path.join(__dirname, 'fixtures', extra1Base)
+  const extra1AbsPath = path.join(__dirname, 'fixtures', extra1Base)
+  const extra1RelPath = path.join('..', extra1Base)
 
-  opts.name = 'extraResourceStringTest'
+  opts.name = 'extraResourceStringTest' + (relative ? '-relative' : '')
   opts.dir = util.fixtureSubdir('basic')
   opts.out = 'dist'
   opts.platform = platform
-  opts.extraResource = extra1Path
+  opts.extraResource = relative ? extra1RelPath : extra1AbsPath
 
   const resourcesPath = await util.packageAndEnsureResourcesPath(t, opts)
-  await util.assertFilesEqual(t, extra1Path, path.join(resourcesPath, extra1Base), 'resource file data1.txt should match')
+  await util.assertFilesEqual(t, extra1AbsPath, path.join(resourcesPath, extra1Base), 'resource file data1.txt should match')
 }
 
-async function createExtraResourceArrayTest (t, opts, platform) {
+async function createExtraResourceArrayTest (t, opts, platform, relative) {
   const extra1Base = 'data1.txt'
-  const extra1Path = path.join(__dirname, 'fixtures', extra1Base)
+  const extra1AbsPath = path.join(__dirname, 'fixtures', extra1Base)
+  const extra1RelPath = path.join('..', extra1Base)
   const extra2Base = 'extrainfo.plist'
-  const extra2Path = path.join(__dirname, 'fixtures', extra2Base)
+  const extra2AbsPath = path.join(__dirname, 'fixtures', extra2Base)
+  const extra2RelPath = path.join('..', extra2Base)
 
-  opts.name = 'extraResourceArrayTest'
+  opts.name = 'extraResourceArrayTest' + (relative ? '-relative' : '')
   opts.dir = util.fixtureSubdir('basic')
   opts.out = 'dist'
   opts.platform = platform
-  opts.extraResource = [extra1Path, extra2Path]
+  opts.extraResource = relative ? [extra1RelPath, extra2RelPath] : [extra1AbsPath, extra2AbsPath]
 
   const resourcesPath = await util.packageAndEnsureResourcesPath(t, opts)
   const extra1DistPath = path.join(resourcesPath, extra1Base)
   const extra2DistPath = path.join(resourcesPath, extra2Base)
   await util.assertPathExists(t, extra1DistPath, 'resource file data1.txt exists')
-  await util.assertFilesEqual(t, extra1Path, extra1DistPath, 'resource file data1.txt should match')
+  await util.assertFilesEqual(t, extra1AbsPath, extra1DistPath, 'resource file data1.txt should match')
   await util.assertPathExists(t, extra2DistPath, 'resource file extrainfo.plist exists')
-  await util.assertFilesEqual(t, extra2Path, extra2DistPath, 'resource file extrainfo.plist should match')
+  await util.assertFilesEqual(t, extra2AbsPath, extra2DistPath, 'resource file extrainfo.plist should match')
 }
 
 for (const platform of ['darwin', 'linux']) {
   test.serial(`extraResource: string (${platform})`, util.testSinglePlatform(createExtraResourceStringTest, platform))
   test.serial(`extraResource: array (${platform})`, util.testSinglePlatform(createExtraResourceArrayTest, platform))
+  const relativePaths = true
+  test.serial(`extraResource (relative): string (${platform})`, util.testSinglePlatform(createExtraResourceStringTest, platform, relativePaths))
+  test.serial(`extraResource (relative): array (${platform})`, util.testSinglePlatform(createExtraResourceArrayTest, platform, relativePaths))
 }
 
 test.serial('building for Linux target sanitizes binary name', util.testSinglePlatform(async (t, opts) => {

--- a/test/darwin.js
+++ b/test/darwin.js
@@ -208,6 +208,13 @@ if (!(process.env.CI && process.platform === 'win32')) {
   test.serial('macOS icon: .ico specified (should replace with .icns)', darwinTest(iconTest, `${iconBase}.ico`, icnsPath))
   test.serial('macOS icon: basename only (should add .icns)', darwinTest(iconTest, iconBase, icnsPath))
 
+  const iconRelBase = path.join('..', 'monochrome')
+  const icnsRelPath = `${iconRelBase}.icns`
+
+  test.serial('macOS icon (relative path): .icns specified', darwinTest(iconTest, icnsRelPath, icnsPath))
+  test.serial('macOS icon (relative path): .ico specified (should replace with .icns)', darwinTest(iconTest, `${iconRelBase}.ico`, icnsPath))
+  test.serial('macOS icon (relative path): basename only (should add .icns)', darwinTest(iconTest, iconRelBase, icnsPath))
+
   const extraInfoPath = path.join(__dirname, 'fixtures', 'extrainfo.plist')
   const extraInfoParams = plist.parse(fs.readFileSync(extraInfoPath).toString())
 
@@ -219,6 +226,10 @@ if (!(process.env.CI && process.platform === 'win32')) {
     const obj = await packageAndParseInfoPlist(t, opts)
     t.false(obj.NSRequiresAquaSystemAppearance, 'NSRequiresAquaSystemAppearance should be set to false')
   }))
+
+  const extraInfoRelPath = path.join('..', 'extrainfo.plist')
+
+  test.serial('extendInfo (relative path): filename', darwinTest(extendInfoTest, extraInfoRelPath))
 
   test.serial('protocol/protocol-name', darwinTest(async (t, opts) => {
     opts.protocols = [


### PR DESCRIPTION
When handling the `icon`, `extendInfo`, and `extraResource` options were interpreting relative paths as relative to the current working directory, rather than relative to the `dir` option.

* [x] I have read the [contribution documentation](https://github.com/electron/electron-packager/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).