### PR TITLE
fix: Ignore node_modules/.bin in all directories

### DIFF
--- a/src/ignore.js
+++ b/src/ignore.js
@@ -9,7 +9,7 @@ const targets = require('./targets')
 
 const DEFAULT_IGNORES = [
   '/\\.git($|/)',
-  '/node_modules/\\.bin($|/)',
+  'node_modules/\\.bin($|/)',
   '\\.o(bj)?$'
 ]
 


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [x] I have read the [contribution documentation](https://github.com/electron/electron-packager/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

`/node_modules/.bin` is excluded from the build by default, but I also had the following directories in my project:

* `node_modules/mocha/node_modules/.bin`
* `my-submodule/node_modules/.bin`
* `my-submodule/node_modules/mocha/node_modules/.bin`

This led to the following issue on packaging: https://github.com/electron-userland/electron-builder/issues/4559

I've modified the pattern to exclude `node_modules/.bin` directories across the project.

Note: this change actually matches the existing documentation in `api.md`.