### PR TITLE
fix(mac): don't fail if the icon path given doesn't exist

### DIFF
--- a/src/mac.js
+++ b/src/mac.js
@@ -288,8 +288,10 @@ class MacApp extends App {
       /* istanbul ignore next */
       return Promise.resolve()
     }
-    debug(`Copying icon "${icon}" to app's Resources as "${this.appPlist.CFBundleIconFile}"`)
-    await fs.copy(icon, path.join(this.originalResourcesDir, this.appPlist.CFBundleIconFile))
+    if (icon) {
+      debug(`Copying icon "${icon}" to app's Resources as "${this.appPlist.CFBundleIconFile}"`)
+      await fs.copy(icon, path.join(this.originalResourcesDir, this.appPlist.CFBundleIconFile))
+    }
   }
 
   async renameAppAndHelpers () {

--- a/src/platform.js
+++ b/src/platform.js
@@ -152,6 +152,9 @@ class App {
 
     if (await fs.pathExists(iconFilename)) {
       return iconFilename
+    } else {
+      /* istanbul ignore next */
+      common.warning(`Could not find icon "${iconFilename}", not updating app icon`)
     }
   }
 


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron/electron-packager/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Noticed in #1100. It generates a warning if the icon specified isn't found.