### PR TITLE
docs: add a link to the Electron docs for darwinDarkModeSupport

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -420,7 +420,8 @@ Valid values are listed in [Apple's documentation](https://developer.apple.com/l
 
 Forces support for Mojave (macOS 10.14) dark mode in your packaged app. This sets the
 `NSRequiresAquaSystemAppearance` key to `false` in your app's `Info.plist`.  For more information,
-see the [Apple developer documentation](https://developer.apple.com/documentation/appkit/nsappearancecustomization/choosing_a_specific_appearance_for_your_app).
+see the [Electron documentation](https://www.electronjs.org/docs/tutorial/mojave-dark-mode-guide)
+and the [Apple developer documentation](https://developer.apple.com/documentation/appkit/nsappearancecustomization/choosing_a_specific_appearance_for_your_app).
 
 ##### `extendInfo`
 


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron/electron-packager/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).

**Summarize your changes:**

Fixes #1107.