### PR TITLE
test: replace tempy with fs.mkdtemp

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,8 +56,7 @@
     "eslint-plugin-standard": "^4.0.0",
     "nyc": "^15.0.0",
     "pkg-up": "^3.0.1",
-    "sinon": "^8.0.1",
-    "tempy": "^0.3.0"
+    "sinon": "^8.0.1"
   },
   "engines": {
     "node": ">= 8.0"

--- a/test/_util.js
+++ b/test/_util.js
@@ -5,12 +5,12 @@ const bufferEqual = require('buffer-equal')
 const common = require('../src/common')
 const config = require('./config.json')
 const fs = require('fs-extra')
+const os = require('os')
 const packager = require('..')
 const path = require('path')
 const plist = require('plist')
 const setup = require('./_setup')
 const sinon = require('sinon')
-const tempy = require('tempy')
 const test = require('ava')
 
 const ORIGINAL_CWD = process.cwd()
@@ -28,9 +28,9 @@ test.after.always(async t => {
   await fs.remove(setup.WORK_CWD)
 })
 
-test.beforeEach(t => {
-  t.context.workDir = tempy.directory()
-  t.context.tempDir = tempy.directory()
+test.beforeEach(async t => {
+  t.context.workDir = await fs.mkdtemp(path.join(os.tmpdir(), 'electron-packager-test-'))
+  t.context.tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'electron-packager-test-'))
 })
 
 test.afterEach.always(async t => {


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron/electron-packager/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Removes a few transitive `devDependencies`.