### PR TITLE
fix(win32): correctly catch missing wine exceptions

### DIFF
--- a/src/win32.js
+++ b/src/win32.js
@@ -92,7 +92,7 @@ class WindowsApp extends App {
       }
 
       debug(`Running rcedit with the options ${JSON.stringify(rcOpts)}`)
-      return require('rcedit')(this.electronBinaryPath, rcOpts)
+      await require('rcedit')(this.electronBinaryPath, rcOpts)
     } catch (err) {
       // Icon might be omitted or only exist in one OS's format, so skip it if normalizeExt reports an error
       /* istanbul ignore next */


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron/electron-packager/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.

**Summarize your changes:**

I noticed that the human-friendly message wasn't getting printed out on a Linux install sans wine.