### PR TITLE
Make 11.x work with Electron 6 and above

### DIFF
--- a/test/_setup.js
+++ b/test/_setup.js
@@ -25,7 +25,14 @@ function downloadAll (version) {
   console.log(`Calling electron-download for ${version} before running tests...`)
   const combinations = download.createDownloadCombos({electronVersion: config.version, all: true}, targets.officialPlatforms, targets.officialArchs, skipDownloadingMacZips)
 
-  return Promise.all(combinations.map(combination => downloadElectronZip(version, combination)))
+  return Promise.all(
+    [
+      ...combinations.map(combination => downloadElectronZip(version, combination)),
+      downloadElectronZip('6.0.0-beta.15', {
+        platform: 'darwin'
+      })
+    ]
+  )
 }
 
 function downloadElectronZip (version, options) {


### PR DESCRIPTION
This PR picks up changes from master which supports Electron 6x: 

To make version 11.x works with Electron 6.x (and above). We need that because we are still using electron-forge version 5.2.4 and electron-forge internally using electron-packager 11.x
