### PR TITLE
fix(typescript): ensure OsxNotarizeOptions definition contains credentials

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -10,7 +10,7 @@
 
 import { CreateOptions as AsarOptions } from 'asar';
 import { ElectronDownloadRequestOptions as ElectronDownloadOptions } from '@electron/get';
-import { NotarizeOptions } from 'electron-notarize';
+import { NotarizeCredentials, TransporterOptions as NotarizeTransporterOptions } from 'electron-notarize';
 import { SignOptions } from 'electron-osx-sign';
 
 /**
@@ -115,7 +115,7 @@ declare namespace electronPackager {
    * See the documentation for [`electron-notarize`](https://npm.im/electron-notarize#method-notarizeopts-promisevoid)
    * for details.
    */
-  type OsxNotarizeOptions = Omit<NotarizeOptions, 'appBundleId' | 'appPath'>;
+  type OsxNotarizeOptions = NotarizeCredentials & NotarizeTransporterOptions;
 
   /**
    * Defines URL protocol schemes to be used on macOS.

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -170,7 +170,7 @@ await packager({
   osxNotarize: {
     appleId: 'My ID',
     appleIdPassword: 'Bad Password',
-  } as packager.OsxNotarizeOptions,
+  },
   osxSign: {
     identity: 'myidentity',
     entitlements: 'path/to/my.entitlements',


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron/electron-packager/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Fixes #1162.