### PR TITLE
test: fix allPlatformArchCombosCount given new win32/arm64 combo

### DIFF
--- a/test/_util.js
+++ b/test/_util.js
@@ -47,7 +47,7 @@ function packagerTestOptions (t) {
 }
 
 module.exports = {
-  allPlatformArchCombosCount: 10,
+  allPlatformArchCombosCount: 12,
   assertDirectory: async function assertDirectory (t, pathToCheck, message) {
     const stats = await fs.stat(pathToCheck)
     t.true(stats.isDirectory(), message)

--- a/test/targets.js
+++ b/test/targets.js
@@ -77,10 +77,10 @@ test('validateListFromOptions works for armv7l host and target arch', t => {
 })
 
 test('build for all available official targets',
-     testMultiTarget({ all: true, electronVersion: '1.8.2' }, util.allPlatformArchCombosCount - 1,
+     testMultiTarget({ all: true, electronVersion: '1.8.2' }, util.allPlatformArchCombosCount - 3,
                      'Packages should be generated for all possible platforms (except win32/arm64)'))
 test('build for all available official targets for a version without arm64 or mips64el support',
-     testMultiTarget({ all: true }, util.allPlatformArchCombosCount - 3,
+     testMultiTarget({ all: true }, util.allPlatformArchCombosCount - 5,
                      'Packages should be generated for all possible platforms (except linux/arm64, linux/mips64el, or win32/arm64)'))
 test('platform=all (one arch)',
      testMultiTarget({ arch: 'ia32', platform: 'all' }, 2, 'Packages should be generated for both 32-bit platforms'))


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron/electron-packager/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Somehow I missed this when merging #1168.