### PR TITLE
fix(targets): allow checking official builds against prerelease versions

### DIFF
--- a/src/targets.js
+++ b/src/targets.js
@@ -79,7 +79,7 @@ function validOfficialPlatformArch (opts, platform, arch) {
 }
 
 function officialBuildExists (opts, buildVersion) {
-  return semver.satisfies(opts.electronVersion, buildVersion)
+  return semver.satisfies(opts.electronVersion, buildVersion, { includePrerelease: true })
 }
 
 function allPlatformsOrArchsSpecified (opts) {

--- a/test/targets.js
+++ b/test/targets.js
@@ -103,6 +103,7 @@ test('fails with invalid platform', util.invalidOptionTest({
 test('invalid official combination', testMultiTarget({ arch: 'ia32', platform: 'darwin' }, 0, 'Package should not be generated for invalid official combination'))
 
 test('platform=linux and arch=arm64 with a supported official Electron version', testMultiTarget({ arch: 'arm64', platform: 'linux', electronVersion: '1.8.0' }, 1, 'Package should be generated for linux/arm64'))
+test('platform=linux and arch=arm64 with a supported official Electron version (11.0.0-beta.22)', testMultiTarget({ arch: 'arm64', platform: 'linux', electronVersion: '11.0.0-beta.22' }, 1, 'Package should be generated for linux/arm64'))
 test('platform=linux and arch=arm64 with an unsupported official Electron version', testMultiTarget({ arch: 'arm64', platform: 'linux' }, 0, 'Package should not be generated for linux/arm64'))
 
 test('platform=linux and arch=mips64el with a supported official Electron version', testMultiTarget({ arch: 'mips64el', platform: 'linux', electronVersion: '1.8.2-beta.5' }, 1, 'Package should be generated for mips64el'))


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [x] I have read the [contribution documentation](https://github.com/electron/electron-packager/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Fixes #1190 

The behavior exhibited by semver in that issue is apparently [intended behavior](https://github.com/npm/node-semver#prerelease-tags), but I don't think it makes much sense in this context, so I've set the option to disable it, which allows ARM64 builds to work as intended.