### PR TITLE
revert: "chore(deps-dev): bump typedoc from 0.19.2 to 0.20.20"

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "pkg-up": "^3.0.1",
     "sinon": "^9.0.0",
     "tsd": "^0.14.0",
-    "typedoc": "^0.20.20",
+    "typedoc": "^0.19.0",
     "typescript": "^4.0.2"
   },
   "engines": {


### PR DESCRIPTION
Reverts electron/electron-packager#1216

Fixes #1217 