### PR TITLE
docs: link to process.resourcesPath with extraResource

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -335,7 +335,9 @@ declare namespace electronPackager {
     extendInfo?: string | { [property: string]: any }; // eslint-disable-line @typescript-eslint/no-explicit-any
     /**
      * One or more files to be copied directly into the app's `Contents/Resources` directory for
-     * macOS target platforms, and the `resources` directory for other target platforms.
+     * macOS target platforms, and the `resources` directory for other target platforms. The
+     * resources directory can be referenced in the packaged app via the
+     * [`process.resourcesPath`](https://www.electronjs.org/docs/api/process#processresourcespath-readonly) value.
      */
     extraResource?: string | string[];
     /**


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron/electron-packager/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).

**Summarize your changes:**

For some reason, `extraResource` didn't link to `process.resourcesPath`, which is how you'd reference packaged files in the resources path to begin with.