### PR TITLE
feat: allow extension of helper app plists with extendHelperInfo

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,10 @@
 * Support for customizing Windows targets on darwin/arm64 (#1260)
 * Support for customizing Windows targets on WSL without Wine installed (#1260)
 
+### Added
+
+* Add `extendHelperInfo` option to allow extend helper app `Info.plist` files
+
 ## [15.2.0] - 2020-12-04
 
 [15.2.0]: https://github.com/electron/electron-packager/compare/v15.1.0...v15.2.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -16,7 +16,7 @@
 
 ### Added
 
-* Add `extendHelperInfo` option to allow extend helper app `Info.plist` files
+* `extendHelperInfo` option to allow extending helper app `Info.plist` files
 
 ## [15.2.0] - 2020-12-04
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,10 @@
 
 [Unreleased]: https://github.com/electron/electron-packager/compare/v15.3.0...main
 
+### Added
+
+* `extendHelperInfo` option to allow extending helper app `Info.plist` files (#1233)
+
 ## [15.3.0] - 2021-07-17
 
 [15.3.0]: https://github.com/electron/electron-packager/compare/v15.2.0...v15.3.0
@@ -13,10 +17,6 @@
 * Bundled app validation to ensure that both `package.json` and the main entry point exist (#1257)
 * Support for customizing Windows targets on darwin/arm64 (#1260)
 * Support for customizing Windows targets on WSL without Wine installed (#1260)
-
-### Added
-
-* `extendHelperInfo` option to allow extending helper app `Info.plist` files
 
 ## [15.2.0] - 2020-12-04
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -334,6 +334,19 @@ declare namespace electronPackager {
      */
     extendInfo?: string | { [property: string]: any }; // eslint-disable-line @typescript-eslint/no-explicit-any
     /**
+     * When the value is a string, specifies the filename of a `plist` file. Its contents are merged
+     * into all the Helper app's `Info.plist` files.
+     * When the value is an `Object`, it specifies an already-parsed `plist` data structure that is
+     * merged into all the Helper app's `Info.plist` files.
+     *
+     * Entries from `extendHelperInfo` override entries in the helpers apps `Info.plist` file supplied by
+     * `electron`, `electron-prebuilt-compile`, or `electron-prebuilt`, but are overridden by other
+     * options such as [[appVersion]] or [[appBundleId]].
+     *
+     * @category macOS
+     */
+    extendHelperInfo?: string | { [property: string]: any }; // eslint-disable-line @typescript-eslint/no-explicit-any
+    /**
      * One or more files to be copied directly into the app's `Contents/Resources` directory for
      * macOS target platforms, and the `resources` directory for other target platforms. The
      * resources directory can be referenced in the packaged app via the

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -335,9 +335,9 @@ declare namespace electronPackager {
     extendInfo?: string | { [property: string]: any }; // eslint-disable-line @typescript-eslint/no-explicit-any
     /**
      * When the value is a string, specifies the filename of a `plist` file. Its contents are merged
-     * into all the Helper app's `Info.plist` files.
+     * into all the Helper apps' `Info.plist` files.
      * When the value is an `Object`, it specifies an already-parsed `plist` data structure that is
-     * merged into all the Helper app's `Info.plist` files.
+     * merged into all the Helper apps' `Info.plist` files.
      *
      * Entries from `extendHelperInfo` override entries in the helper apps' `Info.plist` file supplied by
      * `electron`, `electron-prebuilt-compile`, or `electron-prebuilt`, but are overridden by other

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -339,7 +339,7 @@ declare namespace electronPackager {
      * When the value is an `Object`, it specifies an already-parsed `plist` data structure that is
      * merged into all the Helper app's `Info.plist` files.
      *
-     * Entries from `extendHelperInfo` override entries in the helpers apps `Info.plist` file supplied by
+     * Entries from `extendHelperInfo` override entries in the helper apps' `Info.plist` file supplied by
      * `electron`, `electron-prebuilt-compile`, or `electron-prebuilt`, but are overridden by other
      * options such as [[appVersion]] or [[appBundleId]].
      *

--- a/src/mac.js
+++ b/src/mac.js
@@ -212,7 +212,10 @@ class MacApp extends App {
     }
 
     // Some properties need to go on all helpers as well, version, usage info, etc.
-    const plistsToUpdate = updateIfExists.filter(([key]) => !!this[key]).map(([key]) => key).concat(['appPlist', 'helperPlist'])
+    const plistsToUpdate = updateIfExists
+      .filter(([key]) => !!this[key])
+      .map(([key]) => key)
+      .concat(['appPlist', 'helperPlist'])
 
     if (this.loginHelperPlist) {
       const loginHelperName = common.sanitizeAppName(`${this.appName} Login Helper`)
@@ -222,8 +225,9 @@ class MacApp extends App {
     }
 
     if (this.appVersion) {
+      const appVersionString = '' + this.appVersion
       for (const plistKey of plistsToUpdate) {
-        this[plistKey].CFBundleShortVersionString = this[plistKey].CFBundleVersion = '' + this.appVersion
+        this[plistKey].CFBundleShortVersionString = this[plistKey].CFBundleVersion = appVersionString
       }
     }
 
@@ -251,10 +255,11 @@ class MacApp extends App {
 
     if (this.usageDescription) {
       for (const [type, description] of Object.entries(this.usageDescription)) {
+        const usageTypeKey = `NS${type}UsageDescription`;
         for (const plistKey of plistsToUpdate) {
-          this[plistKey][`NS${type}UsageDescription`] = description
+          this[plistKey][usageTypeKey] = description
         }
-        this.appPlist[`NS${type}UsageDescription`] = description
+        this.appPlist[usageTypeKey] = description
       }
     }
 

--- a/src/mac.js
+++ b/src/mac.js
@@ -255,7 +255,7 @@ class MacApp extends App {
 
     if (this.usageDescription) {
       for (const [type, description] of Object.entries(this.usageDescription)) {
-        const usageTypeKey = `NS${type}UsageDescription`;
+        const usageTypeKey = `NS${type}UsageDescription`
         for (const plistKey of plistsToUpdate) {
           this[plistKey][usageTypeKey] = description
         }

--- a/src/mac.js
+++ b/src/mac.js
@@ -105,8 +105,8 @@ class MacApp extends App {
     return path.join(this.loginItemsPath, 'Electron Login Helper.app')
   }
 
-  updatePlist (base, displayName, identifier, name) {
-    return Object.assign(base, {
+  updatePlist (basePlist, displayName, identifier, name) {
+    return Object.assign(basePlist, {
       CFBundleDisplayName: displayName,
       CFBundleExecutable: common.sanitizeAppName(displayName),
       CFBundleIdentifier: identifier,
@@ -114,7 +114,7 @@ class MacApp extends App {
     })
   }
 
-  updateHelperPlist (base, suffix, identifierIgnoresSuffix) {
+  updateHelperPlist (basePlist, suffix, identifierIgnoresSuffix) {
     let helperSuffix, identifier, name
     if (suffix) {
       helperSuffix = `Helper ${suffix}`
@@ -129,19 +129,19 @@ class MacApp extends App {
       identifier = this.helperBundleIdentifier
       name = this.appName
     }
-    return this.updatePlist(base, `${this.appName} ${helperSuffix}`, identifier, name)
+    return this.updatePlist(basePlist, `${this.appName} ${helperSuffix}`, identifier, name)
   }
 
-  async extendPlist (base, propsOrFilename) {
+  async extendPlist (basePlist, propsOrFilename) {
     if (!propsOrFilename) {
       return Promise.resolve()
     }
 
     if (typeof propsOrFilename === 'string') {
       const plist = await this.loadPlist(propsOrFilename)
-      return Object.assign(base, plist)
+      return Object.assign(basePlist, plist)
     } else {
-      return Object.assign(base, propsOrFilename)
+      return Object.assign(basePlist, propsOrFilename)
     }
   }
 
@@ -232,8 +232,9 @@ class MacApp extends App {
     }
 
     if (this.buildVersion) {
+      const buildVersionString = '' + this.buildVersion
       for (const plistKey of plistsToUpdate) {
-        this[plistKey].CFBundleVersion = '' + this.buildVersion
+        this[plistKey].CFBundleVersion = buildVersionString
       }
     }
 

--- a/test/darwin.js
+++ b/test/darwin.js
@@ -43,9 +43,18 @@ async function parseInfoPlist (t, opts, basePath) {
   return util.parsePlist(t, path.join(basePath, `${opts.name}.app`))
 }
 
+async function parseHelperInfoPlist (t, opts, basePath) {
+  return util.parsePlist(t, path.join(basePath, `${opts.name}.app`, 'Contents', 'Frameworks', `${opts.name} Helper.app`))
+}
+
 async function packageAndParseInfoPlist (t, opts) {
   const finalPath = (await packager(opts))[0]
   return parseInfoPlist(t, opts, finalPath)
+}
+
+async function packageAndParseHelperInfoPlist (t, opts) {
+  const finalPath = (await packager(opts))[0]
+  return parseHelperInfoPlist(t, opts, finalPath)
 }
 
 function assertPlistStringValue (t, obj, property, value, message) {
@@ -106,6 +115,26 @@ async function extendInfoTest (t, baseOpts, extraPathOrParams) {
   assertPlistStringValue(t, obj, 'CFBundleVersion', opts.buildVersion, 'CFBundleVersion should reflect buildVersion argument')
   assertCFBundleIdentifierValue(t, obj, 'com.electron.extratest', 'CFBundleIdentifier should reflect appBundleId argument')
   assertPlistStringValue(t, obj, 'LSApplicationCategoryType', 'public.app-category.music', 'LSApplicationCategoryType should reflect appCategoryType argument')
+  assertPlistStringValue(t, obj, 'CFBundlePackageType', 'APPL', 'CFBundlePackageType should be Electron default')
+}
+
+async function extendHelperInfoTest (t, baseOpts, extraPathOrParams) {
+  const opts = {
+    ...baseOpts,
+    appBundleId: 'com.electron.extratest',
+    buildVersion: '3.2.1',
+    extendHelperInfo: extraPathOrParams,
+    electronVersion: '6.0.0'
+  }
+
+  const obj = await packageAndParseHelperInfoPlist(t, opts)
+  assertPlistStringValue(t, obj, 'TestKeyString', 'String data', 'TestKeyString should come from extendHelperInfo')
+  t.is(obj.TestKeyInt, 12345, 'TestKeyInt should come from extendHelperInfo')
+  t.is(obj.TestKeyBool, true, 'TestKeyBool should come from extendHelperInfo')
+  t.deepEqual(obj.TestKeyArray, ['public.content', 'public.data'], 'TestKeyArray should come from extendHelperInfo')
+  t.deepEqual(obj.TestKeyDict, { Number: 98765, CFBundleVersion: '0.0.0' }, 'TestKeyDict should come from extendHelperInfo')
+  assertPlistStringValue(t, obj, 'CFBundleVersion', opts.buildVersion, 'CFBundleVersion should reflect buildVersion argument')
+  assertCFBundleIdentifierValue(t, obj, 'com.electron.extratest.helper', 'CFBundleIdentifier should reflect appBundleId argument')
   assertPlistStringValue(t, obj, 'CFBundlePackageType', 'APPL', 'CFBundlePackageType should be Electron default')
 }
 
@@ -231,6 +260,13 @@ if (!(process.env.CI && process.platform === 'win32')) {
 
   test.serial('extendInfo: filename', darwinTest(extendInfoTest, extraInfoPath))
   test.serial('extendInfo: params', darwinTest(extendInfoTest, extraInfoParams))
+
+  const extraHelperInfoPath = path.join(__dirname, 'fixtures', 'extrainfo.plist')
+  const extraHelperInfoParams = plist.parse(fs.readFileSync(extraHelperInfoPath).toString())
+
+  test.serial('extendHelperInfo: filename', darwinTest(extendHelperInfoTest, extraHelperInfoPath))
+  test.serial('extendHelperInfo: params', darwinTest(extendHelperInfoTest, extraHelperInfoParams))
+
   test.serial('darwinDarkModeSupport: should enable dark mode in macOS Mojave', darwinTest(async (t, opts) => {
     opts.darwinDarkModeSupport = true
 


### PR DESCRIPTION
For apps that want to customize the Helper app plist files they currently have to do so in an `afterCopy` or other out-of-band step.  Adding `extendHelperInfo` to match `extendInfo` makes it much easier to extend these plist files.

This PR also ensures we set `CFBundleShortVersionString` and `CFBundleVersion` on helper plists.

