### PR TITLE
docs: advertise the Discord server

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,5 +2,5 @@ blank_issues_enabled: false
 
 contact_links:
   - name: Question
-    url: https://electronjs.org/community
-    about: Please ask questions about using Electron Packager in one of the community-driven sites.
+    url: https://discord.gg
+    about: "Please ask questions about using Electron Packager in the official Electron Discord server, at the #electron-packager channel."

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ Package your [Electron](https://electronjs.org) app into OS-specific bundles (`.
 [![CircleCI Build Status](https://circleci.com/gh/electron/electron-packager/tree/master.svg?style=svg)](https://circleci.com/gh/electron/electron-packager/tree/master)
 [![Coverage Status](https://codecov.io/gh/electron/electron-packager/branch/master/graph/badge.svg)](https://codecov.io/gh/electron/electron-packager)
 [![NPM](https://badgen.net/npm/v/electron-packager)](https://npm.im/electron-packager)
-![Dependabot Status](https://flat.badgen.net/dependabot/electron/electron-packager?icon=dependabot)
 [![Discord](https://img.shields.io/discord/745037351163527189?color=blueviolet&logo=discord)](https://discord.gg/electron)
 
 [Supported Platforms](#supported-platforms) |

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Package your [Electron](https://electronjs.org) app into OS-specific bundles (`.
 [![Coverage Status](https://codecov.io/gh/electron/electron-packager/branch/master/graph/badge.svg)](https://codecov.io/gh/electron/electron-packager)
 [![NPM](https://badgen.net/npm/v/electron-packager)](https://npm.im/electron-packager)
 ![Dependabot Status](https://flat.badgen.net/dependabot/electron/electron-packager?icon=dependabot)
+[![Discord](https://img.shields.io/discord/745037351163527189?color=blueviolet&logo=discord)](https://discord.gg/electron)
 
 [Supported Platforms](#supported-platforms) |
 [Installation](#installation) |

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -2,7 +2,9 @@
 
 If you have questions about usage, we encourage you to read the [frequently asked
 questions](https://github.com/electron/electron-packager/blob/master/docs/faq.md),
-and visit one of the several [community-driven sites](https://github.com/electron/electron#community).
+and visit one of the several [community-driven sites](https://github.com/electron/electron#community),
+including the [official Electron Discord server](https://discord.gg/electron), where there is a
+dedicated channel for Electron Packager.
 
 Troubleshooting suggestions can be found in our [contributing
 documentation](https://github.com/electron/electron-packager/blob/master/CONTRIBUTING.md#debugging).


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron/electron-packager/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).

**Summarize your changes:**

Folks with questions about Electron Packager should go to the Discord server.