### PR TITLE
chore: replace references to the default branch

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -7,8 +7,8 @@ labels: "bug :bug:"
 ### Preflight Checklist
 <!-- Please ensure you've completed the following steps by replacing [ ] with [x]-->
 
-* [ ] I have read the [contribution documentation](https://github.com/electron/electron-packager/blob/master/CONTRIBUTING.md) for this project.
-* [ ] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
+* [ ] I have read the [contribution documentation](https://github.com/electron/electron-packager/blob/main/CONTRIBUTING.md) for this project.
+* [ ] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
 * [ ] I have searched the issue tracker for a bug that matches the one I want to file, without success.
 
 ### Issue Details

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,8 +7,8 @@ labels: "enhancement"
 ### Preflight Checklist
 <!-- Please ensure you've completed the following steps by replacing [ ] with [x]-->
 
-* [ ] I have read the [contribution documentation](https://github.com/electron/electron-packager/blob/master/CONTRIBUTING.md) for this project.
-* [ ] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
+* [ ] I have read the [contribution documentation](https://github.com/electron/electron-packager/blob/main/CONTRIBUTING.md) for this project.
+* [ ] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
 * [ ] I have searched the issue tracker for a feature request that matches the one I want to file, without success.
 
 ### Problem Description

--- a/.github/config.yml
+++ b/.github/config.yml
@@ -2,9 +2,9 @@
 
 # Comment to be posted to on first time issues
 newIssueWelcomeComment: |
-  👋 Thanks for opening your first issue here! If you have a question about using Electron Packager, read the [support docs](https://github.com/electron/electron-packager/blob/master/SUPPORT.md). If you're reporting a 🐞 bug, please make sure you include steps to reproduce it. Development and issue triage is community-driven, so please be patient and we will get back to you as soon as we can.
+  👋 Thanks for opening your first issue here! If you have a question about using Electron Packager, read the [support docs](https://github.com/electron/electron-packager/blob/main/SUPPORT.md). If you're reporting a 🐞 bug, please make sure you include steps to reproduce it. Development and issue triage is community-driven, so please be patient and we will get back to you as soon as we can.
 
-  To help make it easier for us to investigate your issue, please follow the [contributing guidelines](https://github.com/electron/electron-packager/blob/master/CONTRIBUTING.md#before-opening-bug-reportstechnical-issues).
+  To help make it easier for us to investigate your issue, please follow the [contributing guidelines](https://github.com/electron/electron-packager/blob/main/CONTRIBUTING.md#before-opening-bug-reportstechnical-issues).
 
 # Configuration for new-pr-welcome - https://github.com/behaviorbot/new-pr-welcome
 
@@ -13,7 +13,7 @@ newPRWelcomeComment: |
   Thanks for opening a pull request!
 
   Here are some highlighted action items that will help get it across the finish line, from the
-  [pull request guidelines](https://github.com/electron/electron-packager/blob/master/CONTRIBUTING.md#filing-pull-requests):
+  [pull request guidelines](https://github.com/electron/electron-packager/blob/main/CONTRIBUTING.md#filing-pull-requests):
   - Follow the [JavaScript coding style](https://standardjs.com/).
   - Run `npm run lint` locally to catch formatting errors earlier.
   - Document any user-facing changes in `NEWS.md` and other docs.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,8 +3,8 @@ Thanks for filing a pull request!
 Please check off all of the steps as they are completed by replacing [ ] with [x].
 -->
 
-* [ ] I have read the [contribution documentation](https://github.com/electron/electron-packager/blob/master/CONTRIBUTING.md) for this project.
-* [ ] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
+* [ ] I have read the [contribution documentation](https://github.com/electron/electron-packager/blob/main/CONTRIBUTING.md) for this project.
+* [ ] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
 * [ ] The changes are appropriately documented (if applicable).
 * [ ] The changes have sufficient test coverage (if applicable).
 * [ ] The testsuite passes successfully on my local machine (if applicable).

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,7 @@ name: Publish documentation
 on:
   push:
     branches:
-      - master
+      - main
     tags:
       - v[0-9]+.[0-9]+.[0-9]+*
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,5 +1,5 @@
 # Code of Conduct
 
 This project is a part of the Electron ecosystem. As such, all contributions to this project follow
-[Electron's code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md)
+[Electron's code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md)
 where appropriate.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Electron Packager is a community-driven project. As such, we welcome and encoura
 contributions. They include, but are not limited to:
 
 - Constructive feedback
-- [Questions about usage](https://github.com/electron/electron-packager/blob/master/SUPPORT.md)
+- [Questions about usage](https://github.com/electron/electron-packager/blob/main/SUPPORT.md)
 - [Bug reports / technical issues](#before-opening-bug-reportstechnical-issues)
 - Documentation changes
 - Feature requests
@@ -14,7 +14,7 @@ We strongly suggest that before filing an issue, you search through the existing
 if it has already been filed by someone else.
 
 This project is a part of the Electron ecosystem. As such, all contributions to this project follow
-[Electron's code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md)
+[Electron's code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md)
 where appropriate.
 
 ## Before opening bug reports/technical issues
@@ -65,7 +65,7 @@ Here are some things to keep in mind as you file pull requests to fix bugs, add 
   Feel free to indicate whether the changes require a major, minor, or patch version bump, as
   prescribed by the [semantic versioning specification](http://semver.org/).
 * Once your pull request is approved, please make sure your commits are rebased onto the latest
-  commit in the master branch, and that you limit/squash the number of commits created to a
+  commit in the main branch, and that you limit/squash the number of commits created to a
   "feature"-level. For instance:
 
 bad:

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-[Unreleased]: https://github.com/electron/electron-packager/compare/v15.2.0...master
+[Unreleased]: https://github.com/electron/electron-packager/compare/v15.2.0...main
 
 ## [15.2.0] - 2020-12-04
 
@@ -787,7 +787,7 @@
 ### Changed
 
 * [win32] `rcedit` dependency updated to 0.4.x. **A new DLL is required to run the new version
-  of rcedit, please see [the documentation](https://github.com/electron/electron-packager/blob/master/README.md#building-windows-apps-from-non-windows-platforms)
+  of rcedit, please see [the documentation](https://github.com/electron/electron-packager/blob/main/README.md#building-windows-apps-from-non-windows-platforms)
   for details**
 * API documentation moved from readme.md to docs/api.md (#296)
 

--- a/README.md
+++ b/README.md
@@ -2,20 +2,20 @@
 
 Package your [Electron](https://electronjs.org) app into OS-specific bundles (`.app`, `.exe`, etc.) via JavaScript or the command line.
 
-[![CircleCI Build Status](https://circleci.com/gh/electron/electron-packager/tree/master.svg?style=svg)](https://circleci.com/gh/electron/electron-packager/tree/master)
-[![Coverage Status](https://codecov.io/gh/electron/electron-packager/branch/master/graph/badge.svg)](https://codecov.io/gh/electron/electron-packager)
+[![CircleCI Build Status](https://circleci.com/gh/electron/electron-packager/tree/main.svg?style=svg)](https://circleci.com/gh/electron/electron-packager/tree/main)
+[![Coverage Status](https://codecov.io/gh/electron/electron-packager/branch/main/graph/badge.svg)](https://codecov.io/gh/electron/electron-packager)
 [![NPM](https://badgen.net/npm/v/electron-packager)](https://npm.im/electron-packager)
 [![Discord](https://img.shields.io/discord/745037351163527189?color=blueviolet&logo=discord)](https://discord.gg/electron)
 
 [Supported Platforms](#supported-platforms) |
 [Installation](#installation) |
 [Usage](#usage) |
-[API](https://electron.github.io/electron-packager/master/) |
-[Contributing](https://github.com/electron/electron-packager/blob/master/CONTRIBUTING.md) |
-[Support](https://github.com/electron/electron-packager/blob/master/SUPPORT.md) |
+[API](https://electron.github.io/electron-packager/main/) |
+[Contributing](https://github.com/electron/electron-packager/blob/main/CONTRIBUTING.md) |
+[Support](https://github.com/electron/electron-packager/blob/main/SUPPORT.md) |
 [Related Apps/Libraries](#related) |
-[FAQ](https://github.com/electron/electron-packager/blob/master/docs/faq.md) |
-[Release Notes](https://github.com/electron/electron-packager/blob/master/NEWS.md)
+[FAQ](https://github.com/electron/electron-packager/blob/main/docs/faq.md) |
+[Release Notes](https://github.com/electron/electron-packager/blob/main/NEWS.md)
 
 ----
 
@@ -73,7 +73,7 @@ via [Homebrew](http://brew.sh/).
 
 ## Usage
 
-JavaScript API usage can be found in the [API documentation](https://electron.github.io/electron-packager/master/modules/electronpackager.html).
+JavaScript API usage can be found in the [API documentation](https://electron.github.io/electron-packager/main/modules/electronpackager.html).
 
 ### From the Command Line
 
@@ -95,8 +95,8 @@ This will:
 * Otherwise, a single bundle for the host platform/architecture will be created.
 
 For an overview of the other optional flags, run `electron-packager --help` or see
-[usage.txt](https://github.com/electron/electron-packager/blob/master/usage.txt). For
-detailed descriptions, see the [API documentation](https://electron.github.io/electron-packager/master/modules/electronpackager.html).
+[usage.txt](https://github.com/electron/electron-packager/blob/main/usage.txt). For
+detailed descriptions, see the [API documentation](https://electron.github.io/electron-packager/main/modules/electronpackager.html).
 
 If `appname` is omitted, this will use the name specified by "productName" or "name" in the nearest package.json.
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,10 +1,10 @@
 # Support for Electron Packager
 
 If you have questions about usage, we encourage you to read the [frequently asked
-questions](https://github.com/electron/electron-packager/blob/master/docs/faq.md),
+questions](https://github.com/electron/electron-packager/blob/main/docs/faq.md),
 and visit one of the several [community-driven sites](https://github.com/electron/electron#community),
 including the [official Electron Discord server](https://discord.gg/electron), where there is a
 dedicated channel for Electron Packager.
 
 Troubleshooting suggestions can be found in our [contributing
-documentation](https://github.com/electron/electron-packager/blob/master/CONTRIBUTING.md#debugging).
+documentation](https://github.com/electron/electron-packager/blob/main/CONTRIBUTING.md#debugging).

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -14,7 +14,7 @@ and packaged modes, you'll need to [define it yourself](https://electronjs.org/d
 
 ## Why isn't my `ignore` option working?
 
-As stated in the documentation for [`ignore`](https://electron.github.io/electron-packager/master/interfaces/electronpackager.options.html#ignore), it uses "[one] or more additional
+As stated in the documentation for [`ignore`](https://electron.github.io/electron-packager/main/interfaces/electronpackager.options.html#ignore), it uses "[one] or more additional
 [regular expression](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions)
 patterns. […] Please note that [glob patterns](https://en.wikipedia.org/wiki/Glob_%28programming%29)
 will not work."
@@ -44,7 +44,7 @@ console.log(require(jsonFilename));
 
 ## How do I set an icon on Linux?
 
-The docs for [`icon`](https://electron.github.io/electron-packager/master/interfaces/electronpackager.options.html#icon)
+The docs for [`icon`](https://electron.github.io/electron-packager/main/interfaces/electronpackager.options.html#icon)
 already show how to set an icon on your `BrowserWindow`, but your dock/taskbar may not use that and
 instead use the `Icon` value in your `.desktop` file. The [Linux distributable creators](https://github.com/electron/electron-packager#distributable-creators)
 can help you set/distribute the appropriate icon in that case.

--- a/src/infer.js
+++ b/src/infer.js
@@ -34,7 +34,7 @@ function errorMessageForProperty (prop) {
 
   return `Unable to determine ${propDescription}. Please specify an ${propDescription}\n\n` +
     'For more information, please see\n' +
-    `https://electron.github.io/electron-packager/master/interfaces/electronpackager.options.html#${hash}\n`
+    `https://electron.github.io/electron-packager/main/interfaces/electronpackager.options.html#${hash}\n`
 }
 
 function resolvePromise (id, options) {

--- a/usage.txt
+++ b/usage.txt
@@ -54,7 +54,7 @@ extra-resource     a file to copy into the app's resources directory
 icon               the local path to an icon file to use as the icon for the app.
                    Note: Format depends on platform.
 ignore             do not copy files into app whose filenames RegExp.match this string. See also:
-                   https://electron.github.io/electron-packager/master/interfaces/electronpackager.options.html#ignore
+                   https://electron.github.io/electron-packager/main/interfaces/electronpackager.options.html#ignore
                    and --no-prune. Can be specified multiple times
 no-deref-symlinks  make sure symlinks are not dereferenced within the app source
 no-junk            do not ignore system junk files from the packaged app


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron/electron-packager/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).

**Summarize your changes:**

The default branch has changed from `master` to `main`, update references as appropriate (`electron/electron` has also changed, so change those references as well).