### PR TITLE
fix(mac): compatibility with electron-notarize@^1.1.0

### DIFF
--- a/.eslintrc.typescript.js
+++ b/.eslintrc.typescript.js
@@ -5,7 +5,8 @@ eslintConfig.parser = '@typescript-eslint/parser'
 eslintConfig.parserOptions.sourceType = 'module'
 eslintConfig.extends.push(
   'plugin:@typescript-eslint/eslint-recommended',
-  'plugin:@typescript-eslint/recommended'
+  'plugin:@typescript-eslint/recommended',
+  'plugin:import/typescript'
 )
 
 eslintConfig.rules['comma-dangle'] = ['error', 'only-multiline']

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "asar": "^3.0.0",
     "cross-spawn-windows-exe": "^1.2.0",
     "debug": "^4.0.1",
-    "electron-notarize": "^1.0.0",
+    "electron-notarize": "^1.1.0",
     "electron-osx-sign": "^0.5.0",
     "extract-zip": "^2.0.0",
     "filenamify": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "asar": "^3.0.0",
     "cross-spawn-windows-exe": "^1.2.0",
     "debug": "^4.0.1",
-    "electron-notarize": "^1.1.0",
+    "electron-notarize": "^1.1.1",
     "electron-osx-sign": "^0.5.0",
     "extract-zip": "^2.0.0",
     "filenamify": "^4.1.0",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -10,8 +10,14 @@
 
 import { CreateOptions as AsarOptions } from 'asar';
 import { ElectronDownloadRequestOptions as ElectronDownloadOptions } from '@electron/get';
-import { NotarizeCredentials, TransporterOptions as NotarizeTransporterOptions } from 'electron-notarize';
+import {
+  LegacyNotarizeCredentials,
+  NotaryToolCredentials,
+  TransporterOptions
+} from 'electron-notarize/lib/types';
 import { SignOptions } from 'electron-osx-sign';
+
+type NotarizeLegacyOptions = LegacyNotarizeCredentials & TransporterOptions;
 
 /**
  * Bundles Electron-based application source code with a renamed/customized Electron executable and
@@ -118,7 +124,9 @@ declare namespace electronPackager {
    * See the documentation for [`electron-notarize`](https://npm.im/electron-notarize#method-notarizeopts-promisevoid)
    * for details.
    */
-  type OsxNotarizeOptions = NotarizeCredentials & NotarizeTransporterOptions;
+  type OsxNotarizeOptions =
+    | ({ tool?: 'legacy' } & NotarizeLegacyOptions)
+    | ({ tool: 'notarytool' } & NotaryToolCredentials);
 
   /**
    * Defines URL protocol schemes to be used on macOS.

--- a/src/mac.js
+++ b/src/mac.js
@@ -6,7 +6,7 @@ const debug = require('debug')('electron-packager')
 const fs = require('fs-extra')
 const path = require('path')
 const plist = require('plist')
-const { notarize, validateAuthorizationArgs } = require('electron-notarize')
+const { notarize } = require('electron-notarize')
 const { signAsync } = require('electron-osx-sign')
 
 class MacApp extends App {
@@ -417,13 +417,6 @@ function createSignOpts (properties, platform, app, version, notarize, quiet) {
 }
 
 function createNotarizeOpts (properties, appBundleId, appPath, quiet) {
-  try {
-    validateAuthorizationArgs(properties)
-  } catch (e) {
-    common.warning(`Failed validation, notarization will not run: ${e.message}`)
-    return
-  }
-
   // osxNotarize options are handed off to the electron-notarize module, but with a few
   // additions from the main options. The user may think they can pass bundle ID or appPath,
   // but they will be ignored.

--- a/src/mac.js
+++ b/src/mac.js
@@ -420,7 +420,9 @@ function createNotarizeOpts (properties, appBundleId, appPath, quiet) {
   // osxNotarize options are handed off to the electron-notarize module, but with a few
   // additions from the main options. The user may think they can pass bundle ID or appPath,
   // but they will be ignored.
-  common.subOptionWarning(properties, 'osxNotarize', 'appBundleId', appBundleId, quiet)
+  if (properties.tool !== 'notarytool') {
+    common.subOptionWarning(properties, 'osxNotarize', 'appBundleId', appBundleId, quiet)
+  }
   common.subOptionWarning(properties, 'osxNotarize', 'appPath', appPath, quiet)
   return properties
 }

--- a/test/darwin.js
+++ b/test/darwin.js
@@ -298,13 +298,6 @@ if (!(process.env.CI && process.platform === 'win32')) {
     t.deepEqual(obj.CFBundleURLTypes, expected, 'CFBundleURLTypes did not contain specified protocol schemes and names')
   }))
 
-  test('osxNotarize: missing appleIdPassword', t => {
-    util.setupConsoleWarnSpy()
-    const notarizeOpts = mac.createNotarizeOpts({ appleId: '' })
-    t.falsy(notarizeOpts, 'does not generate options')
-    util.assertWarning(t, 'WARNING: Failed validation, notarization will not run: The appleId property is required when using notarization with appleIdPassword')
-  })
-
   test('osxNotarize: appBundleId not overwritten', t => {
     const args = { appleId: '1', appleIdPassword: '2', appBundleId: 'no' }
     const notarizeOpts = mac.createNotarizeOpts(args, 'yes', 'appPath', true)

--- a/test/darwin.js
+++ b/test/darwin.js
@@ -298,6 +298,12 @@ if (!(process.env.CI && process.platform === 'win32')) {
     t.deepEqual(obj.CFBundleURLTypes, expected, 'CFBundleURLTypes did not contain specified protocol schemes and names')
   }))
 
+  test('osxNotarize: appBundleId can be overwritten if tool = notarytool', t => {
+    const args = { appleId: '1', appleIdPassword: '2', appBundleId: 'overwritten', tool: 'notarytool' }
+    const notarizeOpts = mac.createNotarizeOpts(args, 'original', 'appPath', true)
+    t.is(notarizeOpts.appBundleId, 'overwritten', 'appBundleId is taken from user-supplied options')
+  })
+
   test('osxNotarize: appBundleId not overwritten', t => {
     const args = { appleId: '1', appleIdPassword: '2', appBundleId: 'no' }
     const notarizeOpts = mac.createNotarizeOpts(args, 'yes', 'appPath', true)


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron/electron-packager/blob/main/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

electron-notarize 1.1.0 added a new mode (using the new `notarytool` binary) which caused `validateAuthorizationArgs` to break.

Update notarization support so that the `tool: notarytool` option works with TypeScript.

Since the module handles its own validation, I'm removing it from this module.

Fixes #1277.