### PR TITLE
feat: automatically insert ElectronAsarIntegrity into Info.plist

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   ],
   "dependencies": {
     "@electron/get": "^1.6.0",
-    "asar": "^3.0.0",
+    "asar": "^3.1.0",
     "cross-spawn-windows-exe": "^1.2.0",
     "debug": "^4.0.1",
     "electron-notarize": "^1.1.1",

--- a/src/mac.js
+++ b/src/mac.js
@@ -183,6 +183,10 @@ class MacApp extends App {
     return plists.concat(optional.filter(item => item))
   }
 
+  appRelativePath (p) {
+    return path.relative(this.contentsPath, p)
+  }
+
   async updatePlistFiles () {
     const appBundleIdentifier = this.bundleName
     this.helperBundleIdentifier = filterCFBundleIdentifier(this.opts.helperBundleId || `${appBundleIdentifier}.helper`)
@@ -190,6 +194,11 @@ class MacApp extends App {
     const plists = await this.determinePlistFilesToUpdate()
     await Promise.all(plists.map(plistArgs => this.loadPlist(...plistArgs)))
     await this.extendPlist(this.appPlist, this.opts.extendInfo)
+    if (this.asarIntegrity) {
+      await this.extendPlist(this.appPlist, {
+        ElectronAsarIntegrity: this.asarIntegrity
+      })
+    }
     this.appPlist = this.updatePlist(this.appPlist, this.executableName, appBundleIdentifier, this.appName)
 
     const updateIfExists = [

--- a/test/darwin.js
+++ b/test/darwin.js
@@ -466,4 +466,24 @@ if (!(process.env.CI && process.platform === 'win32')) {
     await util.assertDirectory(t, appPath, 'The Electron.app folder exists')
     await util.assertFile(t, path.join(appPath, 'Contents', 'MacOS', 'Electron'), 'The Electron.app/Contents/MacOS/Electron binary exists')
   }))
+
+  test.serial('asar integrity hashes are not inserted when asar is disabled', darwinTest(async (t, baseOpts) => {
+    const opts = { ...baseOpts, asar: false }
+    const finalPath = (await packager(opts))[0]
+    const plistObj = await parseInfoPlist(t, opts, finalPath)
+    t.is(typeof plistObj.ElectronAsarIntegrity, 'undefined')
+  }))
+
+  test.serial('asar integrity hashes are automatically inserted', darwinTest(async (t, baseOpts) => {
+    const opts = { ...baseOpts, asar: true }
+    const finalPath = (await packager(opts))[0]
+    const plistObj = await parseInfoPlist(t, opts, finalPath)
+    t.is(typeof plistObj.ElectronAsarIntegrity, 'object')
+    t.deepEqual(plistObj.ElectronAsarIntegrity, {
+      'Resources/app.asar': {
+        algorithm: 'SHA256',
+        hash: '27f2dba4273f6c119000ec7059c27d86e27306d5dbbb83cfdfb862d92c679574'
+      }
+    })
+  }))
 }


### PR DESCRIPTION
Refs https://github.com/electron/electron/pull/30667

Small addition to automatically insert the new (currently optional) `ElectronAsarIntegrity` block into your Info.plist