### PR TITLE
fix: remove ElectronAsarIntegrity when asar is disabled

### DIFF
--- a/src/mac.js
+++ b/src/mac.js
@@ -198,6 +198,10 @@ class MacApp extends App {
       await this.extendPlist(this.appPlist, {
         ElectronAsarIntegrity: this.asarIntegrity
       })
+    } else {
+      await this.extendPlist(this.appPlist, {
+        ElectronAsarIntegrity: null
+      })
     }
     this.appPlist = this.updatePlist(this.appPlist, this.executableName, appBundleIdentifier, this.appName)
 


### PR DESCRIPTION
When `asar` is disabled we should remove the `ElectronAsarIntegrity` field from the `Info.plist`