### PR TITLE
feat: New lifecycle hooks: afterAsar, afterComplete, afterCopyExtraResources, beforeAsar, beforeCopy, beforeCopyExtraResources

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -106,7 +106,8 @@ declare namespace electronPackager {
     /**
      * @param buildPath - For [[afterExtract]], the path to the temporary folder where the prebuilt
      * Electron binary has been extracted to. For [[afterCopy]] and [[afterPrune]], the path to the
-     * folder where the Electron app has been copied to.
+     * folder where the Electron app has been copied to. For [[afterComplete]], the final directory
+     * of the packaged application.
      * @param electronVersion - the version of Electron that is being bundled with the application.
      * @param platform - The target platform you are packaging for.
      * @param arch - The target architecture you are packaging for.
@@ -184,11 +185,23 @@ declare namespace electronPackager {
     /** The source directory. */
     dir: string;
     /**
+     * Functions to be called after your app directory has been packaged into an .asar file.
+     *
+     * **Note**: `afterAsar` will only be called if the [[asar]] option is set.
+     */
+    afterAsar?: HookFunction[];
+    /** Functions to be called after the packaged application has been moved to the final directory. */
+    afterComplete?: HookFunction[];
+    /**
      * Functions to be called after your app directory has been copied to a temporary directory.
      *
      * **Note**: `afterCopy` will not be called if the [[prebuiltAsar]] option is set.
      */
     afterCopy?: HookFunction[];
+    /**
+     * Functions to be called after the files specified in the [[extraResource]] option have been copied.
+     **/
+    afterCopyExtraResources?: HookFunction[];
     /** Functions to be called after the prebuilt Electron binary has been extracted to a temporary directory. */
     afterExtract?: HookFunction[];
     /**
@@ -280,6 +293,22 @@ declare namespace electronPackager {
      * **Note:** `asar` will have no effect if the [[prebuiltAsar]] option is set.
      */
     asar?: boolean | AsarOptions;
+    /**
+     * Functions to be called before your app directory is packaged into an .asar file.
+     *
+     * **Note**: `beforeAsar` will only be called if the [[asar]] option is set.
+     */
+    beforeAsar?: HookFunction[];
+    /**
+     * Functions to be called before your app directory is copied to a temporary directory.
+     *
+     * **Note**: `beforeCopy` will not be called if the [[prebuiltAsar]] option is set.
+     */
+    beforeCopy?: HookFunction[];
+    /**
+     * Functions to be called before the files specified in the [[extraResource]] option are copied.
+     **/
+    beforeCopyExtraResources?: HookFunction[];
     /**
      * The build version of the application. Defaults to the value of the [[appVersion]] option.
      * Maps to the `FileVersion` metadata property on Windows, and `CFBundleVersion` on macOS.

--- a/src/platform.js
+++ b/src/platform.js
@@ -81,9 +81,6 @@ class App {
     ]
   }
 
-  /**
-   * @TODO: rename this into something less verbose or remove it altogether
-   */
   get hookArgsWithOriginalResourcesAppDir () {
     return [
       this.originalResourcesAppDir,

--- a/src/platform.js
+++ b/src/platform.js
@@ -84,10 +84,10 @@ class App {
   /**
    * @TODO: rename this into something less verbose or remove it altogether
    */
-  get hookArgsWithOriginalResourcesAppDir() {
+  get hookArgsWithOriginalResourcesAppDir () {
     return [
       this.originalResourcesAppDir,
-      ...this.commonHookArgs,
+      ...this.commonHookArgs
     ]
   }
 
@@ -263,7 +263,7 @@ class App {
     if (this.opts.afterComplete) {
       const hookArgs = [
         finalPath,
-        ...this.commonHookArgs,
+        ...this.commonHookArgs
       ]
 
       await hooks.promisifyHooks(this.opts.afterComplete, hookArgs)

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -32,15 +32,9 @@ function createHookTest (hookName) {
   return util.packagerTest(async (t, opts) => hookTest(true, hookName, t, opts))
 }
 
-test.serial('platform=all (one arch) for afterInitialize hook', createHookTest('afterInitialize'))
-test.serial('platform=all (one arch) for beforeCopy hook', createHookTest('beforeCopy'))
 test.serial('platform=all (one arch) for afterCopy hook', createHookTest('afterCopy'))
 test.serial('platform=all (one arch) for afterPrune hook', createHookTest('afterPrune'))
 test.serial('platform=all (one arch) for afterExtract hook', createHookTest('afterExtract'))
-test.serial('platform=all (one arch) for beforeAsar hook', createHookTest('beforeAsar'))
-test.serial('platform=all (one arch) for afterAsar hook', createHookTest('afterAsar'))
-test.serial('platform=all (one arch) for beforeCopyExtraResources hook', createHookTest('beforeCopyExtraResources'))
-test.serial('platform=all (one arch) for afterCopyExtraResources hook', createHookTest('afterCopyExtraResources'))
 test.serial('platform=all (one arch) for afterComplete hook', createHookTest('afterComplete'))
 
 test('promisifyHooks executes functions in parallel', async t => {

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -36,6 +36,7 @@ test.serial('platform=all (one arch) for afterInitialize hook', createHookTest('
 test.serial('platform=all (one arch) for beforeCopy hook', createHookTest('beforeCopy'))
 test.serial('platform=all (one arch) for afterCopy hook', createHookTest('afterCopy'))
 test.serial('platform=all (one arch) for afterPrune hook', createHookTest('afterPrune'))
+test.serial('platform=all (one arch) for afterExtract hook', createHookTest('afterExtract'))
 test.serial('platform=all (one arch) for beforeAsar hook', createHookTest('beforeAsar'))
 test.serial('platform=all (one arch) for afterAsar hook', createHookTest('afterAsar'))
 test.serial('platform=all (one arch) for beforeCopyExtraResources hook', createHookTest('beforeCopyExtraResources'))

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -32,9 +32,15 @@ function createHookTest (hookName) {
   return util.packagerTest(async (t, opts) => hookTest(true, hookName, t, opts))
 }
 
+test.serial('platform=all (one arch) for afterInitialize hook', createHookTest('afterInitialize'))
+test.serial('platform=all (one arch) for beforeCopy hook', createHookTest('beforeCopy'))
 test.serial('platform=all (one arch) for afterCopy hook', createHookTest('afterCopy'))
 test.serial('platform=all (one arch) for afterPrune hook', createHookTest('afterPrune'))
-test.serial('platform=all (one arch) for afterExtract hook', createHookTest('afterExtract'))
+test.serial('platform=all (one arch) for beforeAsar hook', createHookTest('beforeAsar'))
+test.serial('platform=all (one arch) for afterAsar hook', createHookTest('afterAsar'))
+test.serial('platform=all (one arch) for beforeCopyExtraResources hook', createHookTest('beforeCopyExtraResources'))
+test.serial('platform=all (one arch) for afterCopyExtraResources hook', createHookTest('afterCopyExtraResources'))
+test.serial('platform=all (one arch) for afterComplete hook', createHookTest('afterComplete'))
 
 test('promisifyHooks executes functions in parallel', async t => {
   let output = '0'

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -32,6 +32,7 @@ function createHookTest (hookName) {
   return util.packagerTest(async (t, opts) => hookTest(true, hookName, t, opts))
 }
 
+test.serial('platform=all (one arch) for beforeCopy hook', createHookTest('beforeCopy'))
 test.serial('platform=all (one arch) for afterCopy hook', createHookTest('afterCopy'))
 test.serial('platform=all (one arch) for afterPrune hook', createHookTest('afterPrune'))
 test.serial('platform=all (one arch) for afterExtract hook', createHookTest('afterExtract'))

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -85,9 +85,15 @@ await packager({
 
 await packager({
   dir: '.',
+  afterAsar: [completeFunction],
+  afterComplete: [completeFunction],
   afterCopy: [completeFunction],
+  afterCopyExtraResources: [completeFunction],
   afterExtract: [completeFunction],
   afterPrune: [completeFunction],
+  beforeAsar: [completeFunction],
+  beforeCopy: [completeFunction],
+  beforeCopyExtraResources: [completeFunction],
   appCopyright: 'Copyright',
   appVersion: '1.0',
   arch: 'ia32',


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [x] I have read the [contribution documentation](https://github.com/electron/electron-packager/blob/main/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**
This PR partially addresses #509 with the following new lifecycle methods: `afterAsar`, `afterComplete`, `afterCopyExtraResources`, `beforeAsar`, `beforeCopy`, `beforeCopyExtraResources`. There's definitely room for improvement, so any feedback is welcome.