### PR TITLE
fix: build universal packages sequentially and allow hooks to return error in TS

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -117,7 +117,7 @@ declare namespace electronPackager {
     electronVersion: string,
     platform: TargetArch,
     arch: TargetArch,
-    callback: () => void
+    callback: (err?: Error | null) => void
   ) => void;
 
   /** See the documentation for [`electron-osx-sign`](https://npm.im/electron-osx-sign#opts) for details. */

--- a/src/universal.js
+++ b/src/universal.js
@@ -26,7 +26,9 @@ async function packageUniversalMac (packageForPlatformAndArchWithOpts, buildDir,
     }
   }
 
-  const [x64AppPath, arm64AppPath] = await Promise.all(['x64', 'arm64'].map((tempArch) => {
+  const tempPackages = {}
+
+  for (const tempArch of ['x64', 'arm64']) {
     const tempOpts = {
       ...comboOpts,
       arch: tempArch,
@@ -40,8 +42,11 @@ async function packageUniversalMac (packageForPlatformAndArchWithOpts, buildDir,
     delete tempOpts.osxSign
     delete tempOpts.osxNotarize
 
-    return packageForPlatformAndArchWithOpts(tempOpts, tempDownloadOpts)
-  }))
+    tempPackages[tempArch] = await packageForPlatformAndArchWithOpts(tempOpts, tempDownloadOpts)
+  }
+
+  const x64AppPath = tempPackages.x64
+  const arm64AppPath = tempPackages.arm64
 
   common.info(`Stitching universal app for platform ${comboOpts.platform}`, comboOpts.quiet)
 


### PR DESCRIPTION
As in title, building in parallel results in some `node-gyp` weirdness and the type for `HookFunction` was wrong