### PR TITLE
feat!: upgrade Node.js to 14 LTS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,21 +46,21 @@ version: 2.1
 orbs:
   win: circleci/windows@2.4.0
 jobs:
-  test-linux-10:
-    docker:
-      - image: circleci/node:10
-    <<: *steps-ci
-  test-linux-12:
-    docker:
-      - image: circleci/node:12
-    <<: *steps-ci
   test-linux-14:
     docker:
       - image: circleci/node:14
     <<: *steps-ci
+  test-linux-16:
+    docker:
+      - image: circleci/node:16
+    <<: *steps-ci
+  test-linux-18:
+    docker:
+      - image: cimg/node:18.7.0
+    <<: *steps-ci
   test-mac:
     macos:
-      xcode: "11.6.0"
+      xcode: "13.3.0"
     <<: *steps-ci
   test-windows:
     executor:
@@ -72,13 +72,13 @@ workflows:
   version: 2
   test:
     jobs:
-      - test-linux-10:
-          filters:
-            branches: { ignore: gh-pages }
-      - test-linux-12:
-          filters:
-            branches: { ignore: gh-pages }
       - test-linux-14:
+          filters:
+            branches: { ignore: gh-pages }
+      - test-linux-16:
+          filters:
+            branches: { ignore: gh-pages }
+      - test-linux-18:
           filters:
             branches: { ignore: gh-pages }
       - test-mac:

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -17,10 +17,10 @@ jobs:
           repository: electron/electron-quick-start
           ref: refs/heads/master
           path: electron-quick-start
-      - name: Use Node.js 10.x
+      - name: Use Node.js 14.x
         uses: actions/setup-node@v2.4.1
         with:
-          node-version: 10.x
+          node-version: 14.x
       - name: Replace electron with electron-nightly
         run: |
           cd electron-quick-start

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,7 +16,7 @@ jobs:
         run: git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
       - uses: actions/setup-node@v2.4.1
         with:
-          node-version: 12.x
+          node-version: 14.x
       - run: npm install --engine-strict --no-lockfile
       - run: npm run docs:build
       - uses: docker://malept/gha-gh-pages:1.3.0

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "typescript": "^4.0.2"
   },
   "engines": {
-    "node": ">= 10.12.0"
+    "node": ">= 14.17.5"
   },
   "scripts": {
     "ava": "ava test/index.js",


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron/electron-packager/blob/main/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Electron Packager is still using Node 10 and Node 12; Node 12 was deprecated in April 2022. This PR requires at least Node 14 LTS, and bumps the automated tests to test on newer versions of Node (14, 16, 18 as opposed to 10, 12, 14).

NB: Since this would be a breaking change, we may want to merge other fixes first and do another release before merging this one.
