### PR TITLE
build: bump @electron/get to 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "usage.txt"
   ],
   "dependencies": {
-    "@electron/get": "^1.6.0",
+    "@electron/get": "^2.0.0",
     "@electron/universal": "^1.2.1",
     "asar": "^3.1.0",
     "cross-spawn-windows-exe": "^1.2.0",


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron/electron-packager/blob/main/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**
Aligns packager with electron core, and fixes a got issue. This PR bumps @electron/get to 2.0.0.
I did not mark this change as a breaking change, because the required version of Node is already 14 and higher; the new minimum version needed for @electron/get is 12.20.55.
