### PR TITLE
chore: remove node 10 job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,10 +46,6 @@ version: 2.1
 orbs:
   win: circleci/windows@2.4.0
 jobs:
-  test-linux-10:
-    docker:
-      - image: circleci/node:10
-    <<: *steps-ci
   test-linux-12:
     docker:
       - image: circleci/node:12
@@ -72,9 +68,6 @@ workflows:
   version: 2
   test:
     jobs:
-      - test-linux-10:
-          filters:
-            branches: { ignore: gh-pages }
       - test-linux-12:
           filters:
             branches: { ignore: gh-pages }


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron/electron-packager/blob/main/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

CI is failing on Node 10 because multiple packages no longer support it (fs-extra, get, etc).
This PR eliminates that job so we can do a stable release. After which, we'll move to Node 14 as a minimum version number.