### PR TITLE
fix: properly import info logger

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { common, hostInfo, warning } = require('./common')
+const { info, hostInfo, warning } = require('./common')
 const fs = require('fs-extra')
 const { initializeProxy } = require('@electron/get')
 const packager = require('..')
@@ -127,9 +127,9 @@ module.exports = {
     try {
       const appPaths = await packager(args)
       if (appPaths.length > 1) {
-        common.info(`Wrote new apps to:\n${appPaths.join('\n')}`)
+        info(`Wrote new apps to:\n${appPaths.join('\n')}`)
       } else if (appPaths.length === 1) {
-        common.info('Wrote new app to', appPaths[0])
+        info('Wrote new app to', appPaths[0])
       }
     } catch (err) {
       if (err.message) {


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [x] I have read the [contribution documentation](https://github.com/electron/electron-packager/blob/main/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [ ] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

ref https://github.com/electron/electron-packager/pull/1361#issuecomment-1223938586

> It appears this breaks the package. An error appears Cannot read properties of undefined (reading 'info') when using electron-packager to package a build. The import { common... should probably have been import { info... and the matching common.info( logs be info( logs.

