### PR TITLE
chore: Revert "chore: bump typedoc from 0.19.2 to 0.23.14 (#1416)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "pkg-up": "^3.0.1",
     "sinon": "^14.0.0",
     "tsd": "^0.14.0",
-    "typedoc": "^0.23.14",
+    "typedoc": "^0.19.0",
     "typescript": "^4.0.2"
   },
   "engines": {


### PR DESCRIPTION
It looks upgrading typedoc broke the docs because of breaking API changes between minor versions.

```
$ node test/ci/build_docs.js
error Tried to set an option (includeDeclarations) that was not declared.
error Tried to set an option (mode) that was not declared.
error Unable to find any entry points. Make sure TypeDoc can find your tsconfig
Could not generate API documentation from TypeScript definition!
error Command failed with exit code 1.
```

https://github.com/electron/electron-packager/actions/runs/3046234742/jobs/4908793618

cc @ckerr 

