### PR TITLE
Fix node version check for legacy projects

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -2,8 +2,9 @@
 
 'use strict'
 
-var nodeVersionInfo = process.versions.node.split('.').map(function (n) { return Number(n) })
-if (nodeVersionInfo < [4, 0, 0]) {
+var isNodeVersionOk = require('./isNodeVersionOk');
+
+if (!isNodeVersionOk(process.versions.node)) {
   console.error('CANNOT RUN WITH NODE ' + process.versions.node)
   console.error('Electron Packager requires Node 4.0 or above.')
   process.exit(1)

--- a/cli.js
+++ b/cli.js
@@ -2,7 +2,7 @@
 
 'use strict'
 
-var isNodeVersionOk = require('./isNodeVersionOk');
+var isNodeVersionOk = require('./isNodeVersionOk')
 
 if (!isNodeVersionOk(process.versions.node)) {
   console.error('CANNOT RUN WITH NODE ' + process.versions.node)

--- a/isNodeVersionOk.js
+++ b/isNodeVersionOk.js
@@ -1,5 +1,7 @@
+'use strict'
+
 module.exports = function (nodeVersion) {
   var nodeVersionInfo = nodeVersion.split('.').map(function (n) { return Number(n) })
-  var nodeVersionMajor = nodeVersionInfo[0];
-  return nodeVersionMajor >= 4;
+  var nodeVersionMajor = nodeVersionInfo[0]
+  return nodeVersionMajor >= 4
 }

--- a/isNodeVersionOk.js
+++ b/isNodeVersionOk.js
@@ -1,0 +1,5 @@
+module.exports = function (nodeVersion) {
+  var nodeVersionInfo = nodeVersion.split('.').map(function (n) { return Number(n) })
+  var nodeVersionMajor = nodeVersionInfo[0];
+  return nodeVersionMajor >= 4;
+}

--- a/test/cli.js
+++ b/test/cli.js
@@ -1,7 +1,23 @@
 'use strict'
 
 const common = require('../common')
-const test = require('tape')
+const isNodeVersionOk = require('../isNodeVersionOk');
+const test = require('tape');
+
+test('CLI node version test: should accept any node that is at least version 4', (t) => {
+  t.equal(isNodeVersionOk('1.0.0'), false)
+  t.equal(isNodeVersionOk('1.5.0'), false)
+  t.equal(isNodeVersionOk('1.0.5'), false)
+  t.equal(isNodeVersionOk('2.0.0'), false)
+  t.equal(isNodeVersionOk('2.5.0'), false)
+  t.equal(isNodeVersionOk('2.0.5'), false)
+  t.equal(isNodeVersionOk('3.0.0'), false)
+  t.equal(isNodeVersionOk('4.0.0'), true)
+  t.equal(isNodeVersionOk('10.0.0'), true)
+  t.equal(isNodeVersionOk('16.0.0'), true)
+  t.equal(isNodeVersionOk('16.16.0'), true)
+  t.end()
+})
 
 test('CLI argument test: --electron-version populates opts.electronVersion', (t) => {
   let args = common.parseCLIArgs([])

--- a/test/cli.js
+++ b/test/cli.js
@@ -1,8 +1,8 @@
 'use strict'
 
 const common = require('../common')
-const isNodeVersionOk = require('../isNodeVersionOk');
-const test = require('tape');
+const isNodeVersionOk = require('../isNodeVersionOk')
+const test = require('tape')
 
 test('CLI node version test: should accept any node that is at least version 4', (t) => {
   t.equal(isNodeVersionOk('1.0.0'), false)


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [x] I have read the [contribution documentation](https://github.com/electron/electron-packager/blob/main/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).
(maybe worth noting: the testsuite had weird fail on the first run when downloading electrons)

**Summarize your changes:**

Comparison between tables worked by accident when node version wasn't starting with "1" when toStringed.
I am aware that 8.7.x is superlegacy branch, but I've found a project that I would like to support and it depends on this version.