### PR TITLE
feat!: upgrade electron-osx-sign to @electron/osx-sign

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,10 @@
 
 [Unreleased]: https://github.com/electron/electron-packager/compare/v16.0.0...main
 
+### Changed
+
+* Replaced `electron-osx-sign` with `@electron/osx-sign`.  The accepted properties on the `osxSign` options object are now slightly different.  Please see the [migration guide](https://github.com/electron/osx-sign/blob/main/MIGRATION.md) for more information on these changes.
+
 ## [16.0.0] - 2022-08-23
 
 [16.0.0]: https://github.com/electron/electron-packager/compare/v15.5.1...v16.0.0

--- a/package.json
+++ b/package.json
@@ -27,12 +27,12 @@
   ],
   "dependencies": {
     "@electron/get": "^2.0.0",
+    "@electron/osx-sign": "^1.0.1",
     "@electron/universal": "^1.2.1",
     "asar": "^3.1.0",
     "cross-spawn-windows-exe": "^1.2.0",
     "debug": "^4.0.1",
     "electron-notarize": "^1.1.1",
-    "electron-osx-sign": "^0.5.0",
     "extract-zip": "^2.0.0",
     "filenamify": "^4.1.0",
     "fs-extra": "^10.1.0",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -15,7 +15,7 @@ import {
   NotaryToolCredentials,
   TransporterOptions
 } from 'electron-notarize/lib/types';
-import { SignOptions } from 'electron-osx-sign';
+import { SignOptions } from '@electron/osx-sign/dist/esm/types';
 import type { makeUniversalApp } from '@electron/universal';
 
 type MakeUniversalOpts = Parameters<typeof makeUniversalApp>[0]
@@ -120,7 +120,7 @@ declare namespace electronPackager {
     callback: (err?: Error | null) => void
   ) => void;
 
-  /** See the documentation for [`electron-osx-sign`](https://npm.im/electron-osx-sign#opts) for details. */
+  /** See the documentation for [`@electron/osx-sign`](https://npm.im/@electron/osx-sign#opts) for details. */
   type OsxSignOptions = Omit<SignOptions, 'app' | 'binaries' | 'platform' | 'version'>;
 
   /**
@@ -444,11 +444,10 @@ declare namespace electronPackager {
     /**
      * If present, signs macOS target apps when the host platform is macOS and XCode is installed.
      * When the value is `true`, pass default configuration to the signing module. See
-     * [electron-osx-sign](https://npm.im/electron-osx-sign#opts---options) for sub-option descriptions and
+     * [@electron/osx-sign](https://npm.im/@electron/osx-sign#opts---options) for sub-option descriptions and
      * their defaults. Options include, but are not limited to:
      * - `identity` (*string*): The identity used when signing the package via `codesign`.
-     * - `entitlements` (*string*): The path to the 'parent' entitlements.
-     * - `entitlements-inherit` (*string*): The path to the 'child' entitlements.
+     * - `binaries` (*array<string>*): Path to additional binaries that will be signed along with built-ins of Electron/
      *
      * @category macOS
      */

--- a/src/mac.js
+++ b/src/mac.js
@@ -7,7 +7,7 @@ const fs = require('fs-extra')
 const path = require('path')
 const plist = require('plist')
 const { notarize } = require('electron-notarize')
-const { signAsync } = require('electron-osx-sign')
+const { signApp } = require('@electron/osx-sign')
 
 class MacApp extends App {
   constructor (opts, templatePath) {
@@ -343,10 +343,10 @@ class MacApp extends App {
     }
 
     if (osxSignOpt) {
-      const signOpts = createSignOpts(osxSignOpt, platform, this.renamedAppPath, version, this.opts.osxNotarize, this.opts.quiet)
-      debug(`Running electron-osx-sign with the options ${JSON.stringify(signOpts)}`)
+      const signOpts = createSignOpts(osxSignOpt, platform, this.renamedAppPath, version, this.opts.quiet)
+      debug(`Running @electron/osx-sign with the options ${JSON.stringify(signOpts)}`)
       try {
-        await signAsync(signOpts)
+        await signApp(signOpts)
       } catch (err) {
         // Although not signed successfully, the application is packed.
         common.warning(`Code sign failed; please retry manually. ${err}`)
@@ -393,7 +393,7 @@ function filterCFBundleIdentifier (identifier) {
   return identifier.replace(/ /g, '-').replace(/[^a-zA-Z0-9.-]/g, '')
 }
 
-function createSignOpts (properties, platform, app, version, notarize, quiet) {
+function createSignOpts (properties, platform, app, version, quiet) {
   // use default sign opts if osx-sign is true, otherwise clone osx-sign object
   const signOpts = properties === true ? { identity: null } : { ...properties }
 
@@ -405,7 +405,7 @@ function createSignOpts (properties, platform, app, version, notarize, quiet) {
   common.subOptionWarning(signOpts, 'osx-sign', 'version', version, quiet)
 
   if (signOpts.binaries) {
-    common.warning('osx-sign.binaries is not an allowed sub-option. Not passing to electron-osx-sign.')
+    common.warning('osx-sign.binaries is not an allowed sub-option. Not passing to @electron/osx-sign.')
     delete signOpts.binaries
   }
 
@@ -414,12 +414,6 @@ function createSignOpts (properties, platform, app, version, notarize, quiet) {
   // autodiscovery. Otherwise, provide signing certificate info.
   if (signOpts.identity === true) {
     signOpts.identity = null
-  }
-
-  if (notarize && !signOpts.hardenedRuntime && !signOpts['hardened-runtime']) {
-    common.warning('notarization is enabled but hardenedRuntime was not enabled in the signing ' +
-      'options. It has been enabled for you but you should enable it in your config.')
-    signOpts.hardenedRuntime = true
   }
 
   return signOpts

--- a/test/cli.js
+++ b/test/cli.js
@@ -46,13 +46,9 @@ test('CLI argument: --osx-sign and --osx-sign subproperties should not be mixed'
 
 test('CLI argument: --osx-sign is object', t => {
   const args = cli.parseArgs([
-    '--osx-sign.identity=identity',
-    '--osx-sign.entitlements-inherit=path',
-    '--osx-sign.hardenedRuntime'
+    '--osx-sign.identity=identity'
   ])
   t.is(args.osxSign.identity, 'identity')
-  t.is(args.osxSign['entitlements-inherit'], 'path')
-  t.true(args.osxSign.hardenedRuntime)
 })
 
 test('CLI argument: --osx-notarize=true', t => {

--- a/test/darwin.js
+++ b/test/darwin.js
@@ -328,10 +328,11 @@ if (!(process.env.CI && process.platform === 'win32')) {
     t.deepEqual(signOpts, { identity: null, app: 'out', platform: 'darwin', version: 'version' })
   })
 
-  test('osxSign: entitlements passed to electron-osx-sign', t => {
-    const args = { entitlements: 'path-to-entitlements' }
+  test('osxSign: optionsForFile passed to @electron/osx-sign', t => {
+    const optionsForFile = () => ({ entitlements: 'path-to-entitlements' })
+    const args = { optionsForFile }
     const signOpts = mac.createSignOpts(args, 'darwin', 'out', 'version')
-    t.deepEqual(signOpts, { app: 'out', platform: 'darwin', version: 'version', entitlements: args.entitlements })
+    t.deepEqual(signOpts, { app: 'out', platform: 'darwin', version: 'version', optionsForFile })
   })
 
   test('osxSign: app not overwritten', t => {
@@ -350,11 +351,6 @@ if (!(process.env.CI && process.platform === 'win32')) {
     const args = { binaries: ['binary1', 'binary2'] }
     const signOpts = mac.createSignOpts(args, 'darwin', 'out', 'version')
     t.deepEqual(signOpts, { app: 'out', platform: 'darwin', version: 'version' })
-  })
-
-  test('force osxSign.hardenedRuntime when osxNotarize is set', t => {
-    const signOpts = mac.createSignOpts({}, 'darwin', 'out', 'version', true)
-    t.true(signOpts.hardenedRuntime, 'hardenedRuntime forced to true')
   })
 
   if (process.platform === 'darwin') {

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -184,8 +184,9 @@ await packager({
   },
   osxSign: {
     identity: 'myidentity',
-    entitlements: 'path/to/my.entitlements',
-    'entitlements-inherit': 'path/to/inherit.entitlements',
+    optionsForFile: () => ({
+      entitlements: 'path/to/my.entitlements',
+    }),
   },
   protocols: [
     {

--- a/usage.txt
+++ b/usage.txt
@@ -84,7 +84,7 @@ helper-bundle-id   bundle identifier to use in the app helper plist
 osx-sign           (macOS host platform only) Whether to sign the macOS app packages. You can either
                    pass --osx-sign by itself to use the default configuration, or use dot notation
                    to configure a list of sub-properties, e.g. --osx-sign.identity="My Name"
-                   For info on supported values see https://npm.im/electron-osx-sign#opts---options
+                   For info on supported values see https://npm.im/@electron/osx-sign#opts---options
                    Properties supported include:
                    - identity: should contain the identity to be used when running `codesign`
                    - entitlements: the path to entitlements used in signing


### PR DESCRIPTION
BREAKING CHANGE: This changes the accepted options for the `osxSign` option.

TODO:
* [x] Write the to-be-linked migration guide