### PR TITLE
refactor: migrate from asar to @electron/asar

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 ### Changed
 
 * Replaced `electron-osx-sign` with `@electron/osx-sign`.  The accepted properties on the `osxSign` options object are now slightly different.  Please see the [migration guide](https://github.com/electron/osx-sign/blob/main/MIGRATION.md) for more information on these changes.
+* Replaced `asar` with `@electron/asar`. The configuration options are unchanged, this migration is purely cosmetic.
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -26,10 +26,10 @@
     "usage.txt"
   ],
   "dependencies": {
+    "@electron/asar": "^3.2.1",
     "@electron/get": "^2.0.0",
     "@electron/osx-sign": "^1.0.1",
-    "@electron/universal": "^1.2.1",
-    "asar": "^3.1.0",
+    "@electron/universal": "^1.3.2",
     "cross-spawn-windows-exe": "^1.2.0",
     "debug": "^4.0.1",
     "electron-notarize": "^1.1.1",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -8,7 +8,7 @@
 // * Mark Lee <https://github.com/malept>
 // * Florian Keller <https://github.com/ffflorian>
 
-import { CreateOptions as AsarOptions } from 'asar';
+import { CreateOptions as AsarOptions } from '@electron/asar';
 import { ElectronDownloadRequestOptions as ElectronDownloadOptions } from '@electron/get';
 import {
   LegacyNotarizeCredentials,

--- a/src/platform.js
+++ b/src/platform.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const asar = require('asar')
+const asar = require('@electron/asar')
 const crypto = require('crypto')
 const debug = require('debug')('electron-packager')
 const fs = require('fs-extra')


### PR DESCRIPTION
Purely cosmetic rename of the `asar` package