### PR TITLE
refactor: migrate from electron-notarize to @electron/notarize

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,10 @@
 
 [Unreleased]: https://github.com/electron/electron-packager/compare/v17.0.0...main
 
+### Changed
+
+* Replaced `electron-notarize` with `@electron/notarize`.  The configuration options are unchanged. This migration is purely cosmetic.
+
 ## [17.0.0]
 
 [17.0.0]: https://github.com/electron/electron-packager/compare/v16.0.0...v17.0.0

--- a/package.json
+++ b/package.json
@@ -28,11 +28,11 @@
   "dependencies": {
     "@electron/asar": "^3.2.1",
     "@electron/get": "^2.0.0",
+    "@electron/notarize": "^1.2.3",
     "@electron/osx-sign": "^1.0.1",
     "@electron/universal": "^1.3.2",
     "cross-spawn-windows-exe": "^1.2.0",
     "debug": "^4.0.1",
-    "electron-notarize": "^1.1.1",
     "extract-zip": "^2.0.0",
     "filenamify": "^4.1.0",
     "fs-extra": "^10.1.0",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -14,7 +14,7 @@ import {
   LegacyNotarizeCredentials,
   NotaryToolCredentials,
   TransporterOptions
-} from 'electron-notarize/lib/types';
+} from '@electron/notarize/lib/types';
 import { SignOptions } from '@electron/osx-sign/dist/esm/types';
 import type { makeUniversalApp } from '@electron/universal';
 
@@ -124,7 +124,7 @@ declare namespace electronPackager {
   type OsxSignOptions = Omit<SignOptions, 'app' | 'binaries' | 'platform' | 'version'>;
 
   /**
-   * See the documentation for [`electron-notarize`](https://npm.im/electron-notarize#method-notarizeopts-promisevoid)
+   * See the documentation for [`@electron/notarize`](https://npm.im/@electron/notarize#method-notarizeopts-promisevoid)
    * for details.
    */
   type OsxNotarizeOptions =
@@ -433,7 +433,7 @@ declare namespace electronPackager {
     name?: string;
     /**
      * If present, notarizes macOS target apps when the host platform is macOS and XCode is installed.
-     * See [`electron-notarize`](https://github.com/electron/electron-notarize#method-notarizeopts-promisevoid)
+     * See [`@electron/notarize`](https://github.com/electron/notarize#method-notarizeopts-promisevoid)
      * for option descriptions, such as how to use `appleIdPassword` safely or obtain an API key.
      *
      * **Requires the [[osxSign]] option to be set.**

--- a/src/mac.js
+++ b/src/mac.js
@@ -6,7 +6,7 @@ const debug = require('debug')('electron-packager')
 const fs = require('fs-extra')
 const path = require('path')
 const plist = require('plist')
-const { notarize } = require('electron-notarize')
+const { notarize } = require('@electron/notarize')
 const { signApp } = require('@electron/osx-sign')
 
 class MacApp extends App {
@@ -422,7 +422,7 @@ function createSignOpts (properties, platform, app, version, quiet) {
 }
 
 function createNotarizeOpts (properties, appBundleId, appPath, quiet) {
-  // osxNotarize options are handed off to the electron-notarize module, but with a few
+  // osxNotarize options are handed off to the @electron/notarize module, but with a few
   // additions from the main options. The user may think they can pass bundle ID or appPath,
   // but they will be ignored.
   if (properties.tool !== 'notarytool') {

--- a/usage.txt
+++ b/usage.txt
@@ -92,7 +92,7 @@ osx-sign           (macOS host platform only) Whether to sign the macOS app pack
 osx-notarize       (macOS host platform only, requires --osx-sign) Whether to notarize the macOS app
                    packages. You must use dot notation to configure a list of sub-properties, e.g.
                    --osx-notarize.appleId="foo@example.com"
-                   For info on supported values see https://npm.im/electron-notarize#method-notarizeopts-promisevoid
+                   For info on supported values see https://npm.im/@electron/notarize#method-notarizeopts-promisevoid
                    Properties supported include:
                    - appleId: should contain your apple ID username / email
                    - appleIdPassword: should contain the password for the provided apple ID


### PR DESCRIPTION
Purely cosmetic rename of the `electron-notarize` package