### PR TITLE
chore: proper npm and Xcode capitalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Package your [Electron](https://electronjs.org) app into OS-specific bundles (`.
 
 [![CircleCI Build Status](https://circleci.com/gh/electron/electron-packager/tree/main.svg?style=svg)](https://circleci.com/gh/electron/electron-packager/tree/main)
 [![Coverage Status](https://codecov.io/gh/electron/electron-packager/branch/main/graph/badge.svg)](https://codecov.io/gh/electron/electron-packager)
-[![NPM](https://badgen.net/npm/v/electron-packager)](https://npm.im/electron-packager)
+[![npm](https://badgen.net/npm/v/electron-packager)](https://npm.im/electron-packager)
 [![Discord](https://img.shields.io/discord/745037351163527189?color=blueviolet&logo=discord)](https://discord.com/invite/APGC3k5yaH)
 
 [Supported Platforms](#supported-platforms) |

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -461,7 +461,7 @@ declare namespace electronPackager {
      */
     name?: string;
     /**
-     * If present, notarizes macOS target apps when the host platform is macOS and XCode is installed.
+     * If present, notarizes macOS target apps when the host platform is macOS and Xcode is installed.
      * See [`@electron/notarize`](https://github.com/electron/notarize#method-notarizeopts-promisevoid)
      * for option descriptions, such as how to use `appleIdPassword` safely or obtain an API key.
      *
@@ -471,7 +471,7 @@ declare namespace electronPackager {
      */
     osxNotarize?: OsxNotarizeOptions;
     /**
-     * If present, signs macOS target apps when the host platform is macOS and XCode is installed.
+     * If present, signs macOS target apps when the host platform is macOS and Xcode is installed.
      * When the value is `true`, pass default configuration to the signing module. See
      * [@electron/osx-sign](https://npm.im/@electron/osx-sign#opts---options) for sub-option descriptions and
      * their defaults. Options include, but are not limited to:


### PR DESCRIPTION
Just a couple of minor capitalization fixes.

References:
- https://github.com/npm/cli#is-it-npm-or-npm-or-npm
- https://developer.apple.com/xcode/