### PR TITLE
fix: ensure logs are quiet when quiet flag is passed

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -52,7 +52,7 @@ module.exports = {
     }
 
     if (args.out === '') {
-      warning('Specifying --out= without a value is the same as the default value')
+      warning('Specifying --out= without a value is the same as the default value', args.quiet)
       args.out = null
     }
 
@@ -60,17 +60,17 @@ module.exports = {
 
     // asar: `Object` or `true`
     if (args.asar === 'true' || args.asar instanceof Array) {
-      warning('--asar does not take any arguments, it only has sub-properties (see --help)')
+      warning('--asar does not take any arguments, it only has sub-properties (see --help)', args.quiet)
       args.asar = true
     }
 
     // osx-sign: `Object` or `true`
     if (args.osxSign === 'true') {
-      warning('--osx-sign does not take any arguments, it only has sub-properties (see --help)')
+      warning('--osx-sign does not take any arguments, it only has sub-properties (see --help)', args.quiet)
       args.osxSign = true
     } else if (typeof args['osx-sign'] === 'object') {
       if (Array.isArray(args['osx-sign'])) {
-        warning('Remove --osx-sign (the bare flag) from the command line, only specify sub-properties (see --help)')
+        warning('Remove --osx-sign (the bare flag) from the command line, only specify sub-properties (see --help)', args.quiet)
       } else {
         // Keep kebab case of sub properties
         args.osxSign = args['osx-sign']
@@ -80,10 +80,10 @@ module.exports = {
     if (args.osxNotarize) {
       let notarize = true
       if (typeof args.osxNotarize !== 'object' || Array.isArray(args.osxNotarize)) {
-        warning('--osx-notarize does not take any arguments, it only has sub-properties (see --help)')
+        warning('--osx-notarize does not take any arguments, it only has sub-properties (see --help)', args.quiet)
         notarize = false
       } else if (!args.osxSign) {
-        warning('Notarization was enabled but macOS code signing was not, code signing is a requirement for notarization, notarize will not run')
+        warning('Notarization was enabled but macOS code signing was not, code signing is a requirement for notarization, notarize will not run', args.quiet)
         notarize = false
       }
 
@@ -94,7 +94,7 @@ module.exports = {
 
     // tmpdir: `String` or `false`
     if (args.tmpdir === 'false') {
-      warning('--tmpdir=false is deprecated, use --no-tmpdir instead')
+      warning('--tmpdir=false is deprecated, use --no-tmpdir instead', args.quiet)
       args.tmpdir = false
     }
 
@@ -127,9 +127,9 @@ module.exports = {
     try {
       const appPaths = await packager(args)
       if (appPaths.length > 1) {
-        info(`Wrote new apps to:\n${appPaths.join('\n')}`)
+        info(`Wrote new apps to:\n${appPaths.join('\n')}`, args.quiet)
       } else if (appPaths.length === 1) {
-        info('Wrote new app to', appPaths[0])
+        info(`Wrote new app to: ${appPaths[0]}`, args.quiet)
       }
     } catch (err) {
       if (err.message) {

--- a/src/common.js
+++ b/src/common.js
@@ -47,7 +47,7 @@ function createAsarOpts (opts) {
   } else if (opts.asar === false || opts.asar === undefined) {
     return false
   } else {
-    warning(`asar parameter set to an invalid value (${opts.asar}), ignoring and disabling asar`)
+    warning(`asar parameter set to an invalid value (${opts.asar}), ignoring and disabling asar`, opts.quiet)
     return false
   }
 
@@ -64,9 +64,9 @@ module.exports = {
 
   createAsarOpts: createAsarOpts,
 
-  deprecatedParameter: function deprecatedParameter (properties, oldName, newName, newCLIName) {
+  deprecatedParameter: function deprecatedParameter (properties, oldName, newName, newCLIName, quiet) {
     if (Object.prototype.hasOwnProperty.call(properties, oldName)) {
-      warning(`The ${oldName} parameter is deprecated, use ${newName} (or --${newCLIName} in the CLI) instead`)
+      warning(`The ${oldName} parameter is deprecated, use ${newName} (or --${newCLIName} in the CLI) instead`, quiet)
       if (!Object.prototype.hasOwnProperty.call(properties, newName)) {
         properties[newName] = properties[oldName]
       }

--- a/src/copy-filter.js
+++ b/src/copy-filter.js
@@ -70,7 +70,7 @@ function generateFilterFunction (ignore) {
 function userPathFilter (opts) {
   const filterFunc = generateFilterFunction(opts.ignore || [])
   const ignoredOutDirs = generateIgnoredOutDirs(opts)
-  const pruner = opts.prune ? new prune.Pruner(opts.dir) : null
+  const pruner = opts.prune ? new prune.Pruner(opts.dir, opts.quiet) : null
 
   return async function filter (file) {
     const fullPath = path.resolve(file)

--- a/src/mac.js
+++ b/src/mac.js
@@ -341,7 +341,7 @@ class MacApp extends App {
     if ((platform === 'all' || platform === 'mas') &&
         osxSignOpt === undefined) {
       common.warning('signing is required for mas builds. Provide the osx-sign option, ' +
-                     'or manually sign the app later.')
+                     'or manually sign the app later.', this.opts.quiet)
     }
 
     if (osxSignOpt) {
@@ -351,7 +351,7 @@ class MacApp extends App {
         await signApp(signOpts)
       } catch (err) {
         // Although not signed successfully, the application is packed.
-        common.warning(`Code sign failed; please retry manually. ${err}`)
+        common.warning(`Code sign failed; please retry manually. ${err}`, this.opts.quiet)
       }
     }
   }
@@ -407,7 +407,7 @@ function createSignOpts (properties, platform, app, version, quiet) {
   common.subOptionWarning(signOpts, 'osx-sign', 'version', version, quiet)
 
   if (signOpts.binaries) {
-    common.warning('osx-sign.binaries is not an allowed sub-option. Not passing to @electron/osx-sign.')
+    common.warning('osx-sign.binaries is not an allowed sub-option. Not passing to @electron/osx-sign.', quiet)
     delete signOpts.binaries
   }
 

--- a/src/platform.js
+++ b/src/platform.js
@@ -172,19 +172,19 @@ class App {
       return iconFilename
     } else {
       /* istanbul ignore next */
-      common.warning(`Could not find icon "${iconFilename}", not updating app icon`)
+      common.warning(`Could not find icon "${iconFilename}", not updating app icon`, this.opts.quiet)
     }
   }
 
   prebuiltAsarWarning (option, triggerWarning) {
     if (triggerWarning) {
-      common.warning(`prebuiltAsar and ${option} are incompatible, ignoring the ${option} option`)
+      common.warning(`prebuiltAsar and ${option} are incompatible, ignoring the ${option} option`, this.opts.quiet)
     }
   }
 
   async copyPrebuiltAsar () {
     if (this.asarOptions) {
-      common.warning('prebuiltAsar has been specified, all asar options will be ignored')
+      common.warning('prebuiltAsar has been specified, all asar options will be ignored', this.opts.quiet)
     }
 
     for (const hookName of ['beforeCopy', 'afterCopy', 'afterPrune']) {

--- a/src/prune.js
+++ b/src/prune.js
@@ -12,8 +12,9 @@ const ELECTRON_MODULES = [
 ]
 
 class Pruner {
-  constructor (dir) {
+  constructor (dir, quiet) {
     this.baseDir = common.normalizePath(dir)
+    this.quiet = quiet
     this.galactus = new galactus.DestroyerOfModules({
       rootDirectory: dir,
       shouldKeepModuleTest: (module, isDevDep) => this.shouldKeepModule(module, isDevDep)
@@ -43,7 +44,7 @@ class Pruner {
     }
 
     if (ELECTRON_MODULES.includes(module.name)) {
-      common.warning(`Found '${module.name}' but not as a devDependency, pruning anyway`)
+      common.warning(`Found '${module.name}' but not as a devDependency, pruning anyway`, this.quiet)
       return false
     }
 

--- a/src/targets.js
+++ b/src/targets.js
@@ -90,7 +90,7 @@ function allPlatformsOrArchsSpecified (opts) {
 
 function warnIfAllNotSpecified (opts, message) {
   if (!allPlatformsOrArchsSpecified(opts)) {
-    common.warning(message)
+    common.warning(message, opts.quiet)
   }
 }
 

--- a/test/basic.js
+++ b/test/basic.js
@@ -74,13 +74,13 @@ test('deprecatedParameter moves value in deprecated param to new param if new pa
   const opts = {
     old: 'value'
   }
-  common.deprecatedParameter(opts, 'old', 'new', 'new-value')
+  common.deprecatedParameter(opts, 'old', 'new', 'new-value', false)
 
   t.false(Object.prototype.hasOwnProperty.call(opts, 'old'), 'old property is not set')
   t.true(Object.prototype.hasOwnProperty.call(opts, 'new'), 'new property is set')
 
   opts.not_overwritten_old = 'another'
-  common.deprecatedParameter(opts, 'not_overwritten_old', 'new', 'new-value')
+  common.deprecatedParameter(opts, 'not_overwritten_old', 'new', 'new-value', false)
 
   t.false(Object.prototype.hasOwnProperty.call(opts, 'not_overwritten_old'), 'not_overwritten_old property is not set')
   t.true(Object.prototype.hasOwnProperty.call(opts, 'new'), 'new property is set')


### PR DESCRIPTION
As in title, we weren't passing `opts/args.quiet` into the common warning and info helpers in a bunch of cases which leads to unwanted logs all over the place 🙃 