### PR TITLE
feat: add support to @electron/fuses

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   ],
   "dependencies": {
     "@electron/asar": "^3.2.1",
+    "@electron/fuses": "^1.6.1",
     "@electron/get": "^2.0.0",
     "@electron/notarize": "^1.2.3",
     "@electron/osx-sign": "^1.0.1",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -17,6 +17,7 @@ import {
 } from '@electron/notarize/lib/types';
 import { SignOptions } from '@electron/osx-sign/dist/esm/types';
 import type { makeUniversalApp } from '@electron/universal';
+import type { FuseConfig } from '@electron/fuses';
 
 type MakeUniversalOpts = Parameters<typeof makeUniversalApp>[0]
 
@@ -410,6 +411,11 @@ declare namespace electronPackager {
      * [`process.resourcesPath`](https://www.electronjs.org/docs/api/process#processresourcespath-readonly) value.
      */
     extraResource?: string | string[];
+    /**
+     * Configuration options for [@electron/fuses](https://github.com/electron/electron/fuses),
+     * which makes it possible to enable/disable some Electron features at packaging-time.
+     */
+    fusesConfig?: FuseConfig
     /**
      * The bundle identifier to use in the application helper's `Info.plist`.
      *

--- a/src/linux.js
+++ b/src/linux.js
@@ -16,6 +16,7 @@ class LinuxApp extends App {
     await this.initialize()
     await this.renameElectron()
     await this.copyExtraResources()
+    await this.flipFuses()
     return this.move()
   }
 }

--- a/src/mac.js
+++ b/src/mac.js
@@ -380,6 +380,7 @@ class MacApp extends App {
     await this.renameElectron()
     await this.renameAppAndHelpers()
     await this.copyExtraResources()
+    await this.flipFuses()
     await this.signAppIfSpecified()
     await this.notarizeAppIfSpecified()
     return this.move()

--- a/src/platform.js
+++ b/src/platform.js
@@ -272,6 +272,18 @@ class App {
 
     return finalPath
   }
+
+  async flipFuses () {
+    const { fusesConfig = {} } = this.opts
+
+    if (Object.keys(fusesConfig).length) {
+      const electronExecutablePath = path.join(this.cachedStagingPath, this.newElectronName)
+
+      const { flipFuses } = require('@electron/fuses')
+
+      await flipFuses(electronExecutablePath, fusesConfig)
+    }
+  }
 }
 
 module.exports = App

--- a/src/win32.js
+++ b/src/win32.js
@@ -102,6 +102,7 @@ class WindowsApp extends App {
     await this.initialize()
     await this.renameElectron()
     await this.copyExtraResources()
+    await this.flipFuses()
     await this.runRcedit()
     return this.move()
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -215,6 +215,15 @@
   optionalDependencies:
     "@types/glob" "^7.1.1"
 
+"@electron/fuses@^1.6.1":
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/@electron/fuses/-/fuses-1.6.1.tgz#c639e018202a59e3cd8911fa943e22c63dd3e6fc"
+  integrity sha512-J7kRMlc0vP03uzUuhHNEqffqZMZ6FRe0YGMOJO4kJObmYkOg38mMTvbbktEj+oteH5nfyhbQUkHIYnMSh7T/CQ==
+  dependencies:
+    chalk "^4.1.1"
+    fs-extra "^9.0.1"
+    minimist "^1.2.5"
+
 "@electron/get@^2.0.0":
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@electron/get/-/get-2.0.2.tgz#ae2a967b22075e9c25aaf00d5941cd79c21efd7e"
@@ -1063,7 +1072,7 @@ chalk@^3.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chalk@^4.0.0, chalk@^4.1.0:
+chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.1:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [x] I have read the [contribution documentation](https://github.com/electron/electron-packager/blob/main/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

This PR brings [@electron/fuses](https://github.com/electron/fuses) support to Packager. I thought it would be better to implement this feature in Packager rather than Forge (see https://github.com/electron/forge/issues/3076) because, well, Forge gets automatic support to it and users running Packager directly also get to use this feature.

I didn't add any tests because testing this feature would require actually packaging an app, and looks like no other test does it ATM, so I decided to check if it's ok first.

Closes https://github.com/electron/forge/issues/3076.
