### PR TITLE
fix(targets): linux/ia32 official support was removed in Electron 19

### DIFF
--- a/src/targets.js
+++ b/src/targets.js
@@ -20,6 +20,7 @@ const buildVersions = {
   },
   linux: {
     arm64: '>= 1.8.0',
+    ia32: '<19.0.0-beta.1',
     mips64el: '^1.8.2-beta.5'
   },
   mas: {

--- a/test/targets.js
+++ b/test/targets.js
@@ -106,6 +106,10 @@ test('platform=linux and arch=arm64 with a supported official Electron version',
 test('platform=linux and arch=arm64 with a supported official Electron version (11.0.0-beta.22)', testMultiTarget({ arch: 'arm64', platform: 'linux', electronVersion: '11.0.0-beta.22' }, 1, 'Package should be generated for linux/arm64'))
 test('platform=linux and arch=arm64 with an unsupported official Electron version', testMultiTarget({ arch: 'arm64', platform: 'linux' }, 0, 'Package should not be generated for linux/arm64'))
 
+test('platform=linux and arch=ia32 with a supported official Electron version', testMultiTarget({ arch: 'ia32', platform: 'linux', electronVersion: '10.0.0' }, 1, 'Package should be generated for linux/ia32'))
+test('platform=linux and arch=ia32 with an unsupported official Electron version (19.0.0-beta.1)', testMultiTarget({ arch: 'ia32', platform: 'linux', electronVersion: '19.0.0-beta.1' }, 0, 'Package should not be generated for linux/ia32'))
+test('platform=linux and arch=ia32 with an unsupported official Electron version', testMultiTarget({ arch: 'ia32', platform: 'linux', electronVersion: '20.0.0' }, 0, 'Package should not be generated for linux/ia32'))
+
 test('platform=linux and arch=mips64el with a supported official Electron version', testMultiTarget({ arch: 'mips64el', platform: 'linux', electronVersion: '1.8.2-beta.5' }, 1, 'Package should be generated for mips64el'))
 test('platform=linux and arch=mips64el with an unsupported official Electron version', testMultiTarget({ arch: 'mips64el', platform: 'linux' }, 0, 'Package should not be generated for linux/mips64el'))
 test('platform=linux and arch=mips64el with an unsupported official Electron version (2.0.0)', testMultiTarget({ arch: 'mips64el', platform: 'linux', electronVersion: '2.0.0' }, 0, 'Package should not be generated for linux/mips64el'))


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron/electron-packager/blob/main/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes have sufficient test coverage (if applicable).
* [ ] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Compare the assets of [19.0.0-alpha.5](https://github.com/electron/electron/releases/tag/v19.0.0-alpha.5) with [19.0.0-beta.1](https://github.com/electron/electron/releases/tag/v19.0.0-beta.1).

Fixes #1447 