### PR TITLE
Add basename option

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -12,7 +12,7 @@ function sanitizeAppName (name) {
 }
 
 function generateFinalBasename (opts) {
-  return `${sanitizeAppName(opts.name)}-${opts.platform}-${opts.arch}`
+  return `${sanitizeAppName(opts.basename || opts.name)}-${opts.platform}-${opts.arch}`
 }
 
 function generateFinalPath (opts) {

--- a/src/copy-filter.js
+++ b/src/copy-filter.js
@@ -40,6 +40,7 @@ function generateIgnoredOutDirs (opts) {
       for (const arch of archs) {
         const basenameOpts = {
           arch: arch,
+          basename: opts.basename,
           name: opts.name,
           platform: platform
         }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -464,6 +464,14 @@ declare namespace electronPackager {
      */
     junk?: boolean;
     /**
+     * The base folder ${basename}-${platform}-${arch}. If omitted, it will use the `productName` or `name` value from the
+     * nearest `package.json`.
+     *
+     * **Regardless of source, characters in the Electron app name which are not allowed in all target
+     * platforms' filenames (e.g., `/`), will be replaced by hyphens (`-`).**
+     */
+    basename?: string;
+    /**
      * The application name. If omitted, it will use the `productName` or `name` value from the
      * nearest `package.json`.
      *

--- a/test/basic.js
+++ b/test/basic.js
@@ -59,6 +59,16 @@ test('sanitize app name for use in the out directory name', t => {
   t.is(common.generateFinalBasename(opts), '@username-package-name-linux-x64', 'generateFinalBasename output should be sanitized')
 })
 
+test('basename should be used in the out directory name', t => {
+  const opts = {
+    arch: 'x64',
+    name: 'app name',
+    basename: 'myapp',
+    platform: 'linux'
+  }
+  t.is(common.generateFinalBasename(opts), 'myapp-linux-x64', 'generateFinalBasename output should use basename over name')
+})
+
 test('cannot build apps where the name ends in " Helper"', async t => {
   const opts = {
     arch: 'x64',


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [x] I have read the [contribution documentation](https://github.com/electron/electron-packager/blob/main/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**
Add basename option to `generateFinalBasename`, that we could avoid [this error](https://github.com/nodejs/node-gyp/issues/65) if the appname has space.
