### PR TITLE
build: update electron/electron-quick-start branch to main

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab  # tag: v3.5.2
         with:
           repository: electron/electron-quick-start
-          ref: refs/heads/master
+          ref: refs/heads/main
           path: electron-quick-start
       - name: Use Node.js 14.x
         uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c  # tag: v3.6.0


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [x] I have read the [contribution documentation](https://github.com/electron/electron-packager/blob/main/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.

**Summarize your changes:**

The default branch for `electron/electron-quick-start` has moved to `main` and that is causing some [GHA workflow failures](https://github.com/electron/electron-packager/actions/runs/4869795755/jobs/8684739009#step:2:55) for the canary workflow.