### PR TITLE
fix(docs): add `osx-universal` flag to usage.txt

### DIFF
--- a/usage.txt
+++ b/usage.txt
@@ -98,6 +98,11 @@ osx-notarize       (macOS host platform only, requires --osx-sign) Whether to no
                    - appleIdPassword: should contain the password for the provided apple ID
                    - appleApiKey: should contain an App Store Connect API key
                    - appleApiIssuer: should contain the API key's issuer
+osx-universal      (macOS host platform only, requires --arch=universal) Options to pass to `@electron/universal`
+                   when packaging a Universal macOS binary. You must use dot notation to configure a list of sub-properties,
+                   e.g. --osx-universal.mergeASARs="true"
+                   For info on supported values see
+                   https://electron.github.io/electron-packager/main/modules/electronpackager.html#osxuniversaloptions
 protocol           URL protocol scheme to register the app as an opener of.
                    For example, `--protocol=myapp` would register the app to open
                    URLs such as `myapp://path`. This argument requires a `--protocol-name`


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [x] I have read the [contribution documentation](https://github.com/electron/electron-packager/blob/main/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.

**Summarize your changes:**

In https://github.com/electron/electron-packager/pull/1346, we added support for the `--arch=universal` flag, but never properly documented CLI usage of the associated `OsxUniversalOptions`.

For the future, we should also document the `@electron/universal` options better. We currently have no docs around these flags outside of the source code.

I tested the syntax by running the following command:

```
DEBUG=electron-universal npx electron-packager . --arch=universal --osx-universal.mergeASARs="true"
```

From here, I was able to confirm that the Universal package was receiving the options properly:

```
  electron-universal making a universal app with options {
  mergeASARs: 'true',
  x64AppPath: '/var/folders/wy/zjrnw32x2496ydq6ps7vljfc0000gp/T/electron-packager/electron-packager-universal-sTH01I/electron-quick-start-darwin-x64/electron-quick-start.app',
  arm64AppPath: '/var/folders/wy/zjrnw32x2496ydq6ps7vljfc0000gp/T/electron-packager/electron-packager-universal-sTH01I/electron-quick-start-darwin-arm64/electron-quick-start.app',
  outAppPath: '/var/folders/wy/zjrnw32x2496ydq6ps7vljfc0000gp/T/electron-packager/darwin-universal/electron-quick-start-darwin-universal-ZMutzn/electron-quick-start.app'
}
```