### PR TITLE
fix: prune `electron-nightly` even if in dependencies

### DIFF
--- a/src/prune.js
+++ b/src/prune.js
@@ -7,6 +7,7 @@ const path = require('path')
 
 const ELECTRON_MODULES = [
   'electron',
+  'electron-nightly',
   'electron-prebuilt',
   'electron-prebuilt-compile'
 ]


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [x] I have read the [contribution documentation](https://github.com/electron/electron-packager/blob/main/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

If `electron-nightly` is installed in `dependencies` by accident, we want to prune it.