### PR TITLE
ci: make canary run `--arch=universal` on macOS

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -2,23 +2,24 @@ name: electron-nightly Canary
 
 on:
   schedule:
-    - cron: '15 8 * * *'
+    - cron: "15 8 * * *"
+  pull_request:
 
 jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest, macOS-latest, ubuntu-latest]
+        os: [macOS-latest, ubuntu-latest]
 
     steps:
-      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9  # tag: v3.5.3
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # tag: v3.5.3
         with:
           repository: electron/electron-quick-start
           ref: refs/heads/main
           path: electron-quick-start
       - name: Use Node.js 14.x
-        uses: actions/setup-node@e33196f7422957bea03ed53f6fbb155025ffc7b8  # tag: v3.7.0
+        uses: actions/setup-node@e33196f7422957bea03ed53f6fbb155025ffc7b8 # tag: v3.7.0
         with:
           node-version: 14.x
       - name: Replace electron with electron-nightly
@@ -31,10 +32,13 @@ jobs:
         run: |
           cd electron-quick-start
           npm install --save-dev electron-packager@electron/electron-packager
+        shell: bash
       - name: Package
         run: |
           cd electron-quick-start
-          if [ "${{ matrix.os }}" = "macOS-latest" ]; then
+          if [ "${{ matrix.os }}" == "macOS-latest" ]; then
             node_modules/.bin/electron-packager . --arch=universal
           else
             node_modules/.bin/electron-packager . --arch=all
+          fi
+        shell: bash

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -3,7 +3,6 @@ name: electron-nightly Canary
 on:
   schedule:
     - cron: "15 8 * * *"
-  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -34,4 +34,7 @@ jobs:
       - name: Package
         run: |
           cd electron-quick-start
-          node_modules/.bin/electron-packager . --arch=all
+          if [ "${{ matrix.os }}" = "macOS-latest" ]; then
+            node_modules/.bin/electron-packager . --arch=universal
+          else
+            node_modules/.bin/electron-packager . --arch=all

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macOS-latest, ubuntu-latest, windows-latest]
+        os: [windows-latest, macOS-latest, ubuntu-latest]
 
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # tag: v3.5.3

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macOS-latest, ubuntu-latest]
+        os: [macOS-latest, ubuntu-latest, windows-latest]
 
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # tag: v3.5.3


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [x] I have read the [contribution documentation](https://github.com/electron/electron-packager/blob/main/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

## Summary

Our `electron-nightly` canary job runs the latest nightly version of Electron against the `main` branch of Electron Packager.

This job has been busted for a while, and it seems because `--arch=all` does not work on macOS ever since we. This is a separate issue, but for now, let's just create a single `--arch=universal` job so that we can unblock the canary.

## Testing

See **https://github.com/electron/electron-packager/pull/1539/commits/c7a3088fc7493c7922f3ac1a7ef35a17bdd7bfa6** for that job running on this PR.
