### PR TITLE
test: set `cacheRoot` on checksum download

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,10 @@ steps-ci: &steps-ci
           *) yarn install --frozen-lockfile ;;
         esac
     - *step-restore-electron-cache
-    - run: test/ci/_before_script.js
+    - run:
+        name: Download Electron binaries
+        command: |
+          node test/ci/_before_script.js
     - *step-save-electron-cache
     - run: yarn run lint
     - run: yarn run tsd

--- a/test/_setup.js
+++ b/test/_setup.js
@@ -49,6 +49,7 @@ async function downloadAll (version) {
 async function downloadElectronChecksum (version) {
   return downloadArtifact({
     isGeneric: true,
+    cacheRoot: path.join(os.homedir(), '.electron'),
     version,
     artifactName: 'SHASUMS256.txt'
   })


### PR DESCRIPTION
## Checklist

* [x] I have read the [contribution documentation](https://github.com/electron/electron-packager/blob/main/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

## Summary

Fixes #1421.

Our `test-linux` suite has had a very poor 52% success rate according to CircleCI insights. Each one of the Linux test suites seems to fail about 1/5 of the time.

| Job Name        | Total Credits | P95 Duration (seconds) | Runs | Success Rate |
|-----------------|---------------|------------------------|------|--------------|
| "test-linux-14" | 517           | 227                    | 17   | 0.82         |
| "test-linux-16" | 539           | 220                    | 19   | 0.79         |
| "test-linux-18" | 542           | 271                    | 16   | 0.81         |
| "test-mac"      | 3031          | 329                    | 15   | 1            |
| "test-windows"  | 1974          | 272                    | 17   | 0.88         |

The observed error was always the following:

```
Downloading Electron v1.4.13 before running tests...
Error: dest already exists.
    at /home/circleci/project/node_modules/@electron/get/node_modules/fs-extra/lib/move/move.js:41:31
    at /home/circleci/project/node_modules/@electron/get/node_modules/universalify/index.js:23:46

Exited with code exit status 1
```

This error occurred in [our test setup code](https://github.com/electron/electron-packager/blob/6430d3f1dff8ffa41540b53c2315388c8d5a6f9b/test/_setup.js#L34C1-L47), which downloads Electron with `@electron/get` before running the test suite. During this setup process, we download the checksum first as of commit 621560b. 

To investigate, I added the `DEBUG=@electron/get*` environment variable in CI to get verbose debug logging. Two things seem to be occurring:

1. The initial checksum download is set without a cache folder, so it never gets written to the cache after being downloaded.

```
Downloading Electron v1.4.13 before running tests...
  @electron/get:index Checking the cache (undefined) for SHASUMS256.txt (https://github.com/electron/electron/releases/download/v1.4.13/SHASUMS256.txt) +0ms
  @electron/get:index Cache miss +3ms
```

2. The setup process downloads the SHASUM256.txt checksums with cache misses for each binary. Since these downloads are done in parallel, the filesystem operations run into a race condition:

```
  @electron/get:cache Moving /tmp/electron-download-gaC39r/SHASUMS256.txt to /home/circleci/.electron/4660c2617dcac48c05988e181e4f7ff85132cd278bba79561816d3e7da1cc50c/SHASUMS256.txt +12ms
  @electron/get:cache * Replacing existing file +0ms
  @electron/get:cache Moving /tmp/electron-download-mSMl8f/SHASUMS256.txt to /home/circleci/.electron/4660c2617dcac48c05988e181e4f7ff85132cd278bba79561816d3e7da1cc50c/SHASUMS256.txt +7ms
  @electron/get:cache Moving /tmp/electron-download-oB433U/SHASUMS256.txt to /home/circleci/.electron/4660c2617dcac48c05988e181e4f7ff85132cd278bba79561816d3e7da1cc50c/SHASUMS256.txt +12ms
  @electron/get:cache * Replacing existing file +1ms
  @electron/get:cache Moving /tmp/electron-download-SeHepQ/SHASUMS256.txt to /home/circleci/.electron/4660c2617dcac48c05988e181e4f7ff85132cd278bba79561816d3e7da1cc50c/SHASUMS256.txt +18ms
Error: dest already exists.
    at /home/circleci/project/node_modules/@electron/get/node_modules/fs-extra/lib/move/move.js:41:31
    at /home/circleci/project/node_modules/@electron/get/node_modules/universalify/index.js:23:46
```

## Fix

To fix this, I set a `cacheRoot` on the initial SHASUM256.txt download so that we get cache hits when downloading the checksums during the binary download. I'm assuming this is the right fix since we must have pre-downloaded the checksums for a reason.

## Evaluation

I got CI to pass 10x in a row! With the 52% success rate, this had a 0.145% chance of happening.

![image](https://github.com/electron/electron-packager/assets/16010076/2af03a55-f136-4e35-bbf9-d51bc9b0ccf7)

