### PR TITLE
ci: use electronjs/node orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,92 +1,67 @@
-step-env: &step-env
-  run:
-    # prevent Wine popup dialogs about installing additional packages
-    name: Setup Environment Variables
-    command: |
-      echo 'export WINEDLLOVERRIDES="mscoree,mshtml="' >> $BASH_ENV
-      echo 'export WINEDEBUG="-all"' >> $BASH_ENV
-
-step-restore-electron-cache: &step-restore-electron-cache
-  restore_cache:
-    name: Restoring Electron cache
-    paths:
-      - $HOME/.cache/electron
-    keys:
-      - v1-electron-cache-{{ arch }}
-
-step-save-electron-cache: &step-save-electron-cache
-  save_cache:
-    name: Persisting Electron cache
-    paths:
-      - $HOME/.cache/electron
-    key: v1-electron-cache-{{ arch }}
-
-step-before-install: &step-before-install
-  run: test/ci/before_install.sh
-
-steps-ci: &steps-ci
-  steps:
-    - checkout
-    - *step-env
-    - *step-before-install
-    - run: |
-        case "$(uname -s)" in
-          "Darwin"|"Linux") yarn install --frozen-lockfile ;;
-          *) yarn install --frozen-lockfile ;;
-        esac
-    - *step-restore-electron-cache
-    - run:
-        name: Download Electron binaries
-        command: |
-          node test/ci/_before_script.js
-    - *step-save-electron-cache
-    - run: yarn run lint
-    - run: yarn run tsd
-    - run: yarn run coverage
-    - run: yarn run codecov
-
 version: 2.1
+
 orbs:
-  win: circleci/windows@2.4.0
+  node: electronjs/node@1.2.0
+
 jobs:
-  test-linux-14:
-    docker:
-      - image: cimg/node:14.21
-    <<: *steps-ci
-  test-linux-16:
-    docker:
-      - image: cimg/node:16.20
-    <<: *steps-ci
-  test-linux-18:
-    docker:
-      - image: cimg/node:18.7.0
-    <<: *steps-ci
-  test-mac:
-    macos:
-      xcode: "13.3.0"
-    <<: *steps-ci
-  test-windows:
-    executor:
-      name: win/default
-      shell: bash.exe
-    <<: *steps-ci
+  test:
+    environment:
+      # prevent Wine popup dialogs about installing additional packages
+      WINEDLLOVERRIDES: mscoree,mshtml=
+      WINEDEBUG: -all
+    executor: <<parameters.executor>>
+    parameters:
+      executor:
+        description: The executor to use for the job.
+        type: string
+      node-version:
+        description: Specify the Node.js version to install.
+        type: string
+    steps:
+      - node/test:
+          post-node-js-install-steps:
+            - run: test/ci/before_install.sh
+          test-steps:
+            - restore_cache:
+                name: Restoring Electron cache
+                paths:
+                  - $HOME/.cache/electron
+                keys:
+                  - v1-electron-cache-{{ arch }}
+            - run:
+                name: Download Electron binaries
+                command: |
+                  node test/ci/_before_script.js
+            - save_cache:
+                name: Persisting Electron cache
+                paths:
+                  - $HOME/.cache/electron
+                key: v1-electron-cache-{{ arch }}
+            - run: yarn run lint
+            - run: yarn run tsd
+            - run: yarn run coverage
+            - run: yarn run codecov
+          use-test-steps: true
+          node-version: << parameters.node-version >>
 
 workflows:
-  version: 2
-  test:
+  test_and_release:
+    # Run the test jobs first, then the release only when all the test jobs are successful
     jobs:
-      - test-linux-14:
+      - test:
+          name: test-<< matrix.executor >>-<< matrix.node-version >>
+          matrix:
+            alias: test
+            parameters:
+              executor:
+                - node/linux
+                - node/macos
+                - node/windows
+              node-version:
+                - 20.2.0
+                - 18.14.0
+                - 16.19.0
+                - 14.19.0
           filters:
             branches: { ignore: gh-pages }
-      - test-linux-16:
-          filters:
-            branches: { ignore: gh-pages }
-      - test-linux-18:
-          filters:
-            branches: { ignore: gh-pages }
-      - test-mac:
-          filters:
-            branches: { ignore: gh-pages }
-      - test-windows:
-          filters:
-            branches: { ignore: gh-pages }
+


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [x] I have read the [contribution documentation](https://github.com/electron/electron-packager/blob/main/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.

**Summarize your changes:**

Fixes failing CI due to no longer supported Xcode version.

Use `electronjs/node` orb to pick up caching of Node.js installs, and simplify this CircleCI config.