### PR TITLE
ci: fix publish documentation workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,9 +7,13 @@ on:
     tags:
       - v[0-9]+.[0-9]+.[0-9]+*
 
+permissions: {}
+
 jobs:
   docs:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9  # tag: v3.5.3
       - name: Fetch all git branches
@@ -19,14 +23,14 @@ jobs:
           node-version: 14.x
       - run: npm install --engine-strict --no-lockfile
       - run: npm run docs:build
-      - uses: docker://malept/gha-gh-pages:1.3.0
+      - uses: dsanders11/github-action-gh-pages@6837fa66857ff3234e3ea5bcf709c86767ae3ce1
         with:
           defaultBranch: main
           docsPath: typedoc
-          gitCommitEmail: 'electron-bot@users.noreply.github.com'
+          gitCommitEmail: 'github-actions@github.com'
           gitCommitMessage: 'Publish [skip ci]'
-          gitCommitUser: 'Electron Bot'
+          gitCommitUser: 'github-actions'
           showUnderscoreFiles: true
           versionDocs: true
         env:
-          GH_PAGES_SSH_DEPLOY_KEY: ${{ secrets.DOCS_SSH_DEPLOY_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [x] I have read the [contribution documentation](https://github.com/electron/electron-packager/blob/main/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.

**Summarize your changes:**

Picks up [some upstream fixes](https://github.com/malept/github-action-gh-pages/compare/main...dsanders11:github-action-gh-pages:2023) and uses the built-in `GITHUB_TOKEN` to do the `git push`, [as documented here](https://github.com/actions/checkout#push-a-commit-using-the-built-in-token).

Ideally will get the fixes upstreamed to `malept/github-action-gh-pages` and we can switch back to that.