### PR TITLE
fix(osx-sign): bump osx-sign to 1.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@electron/asar": "^3.2.1",
     "@electron/get": "^2.0.0",
     "@electron/notarize": "^1.2.3",
-    "@electron/osx-sign": "^1.0.1",
+    "@electron/osx-sign": "^1.0.5",
     "@electron/universal": "^1.3.2",
     "cross-spawn-windows-exe": "^1.2.0",
     "debug": "^4.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -236,10 +236,10 @@
     debug "^4.1.1"
     fs-extra "^9.0.1"
 
-"@electron/osx-sign@^1.0.1":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@electron/osx-sign/-/osx-sign-1.0.4.tgz#8e91442846471636ca0469426a82b253b9170151"
-  integrity sha512-xfhdEcIOfAZg7scZ9RQPya1G1lWo8/zMCwUXAulq0SfY7ONIW+b9qGyKdMyuMctNYwllrIS+vmxfijSfjeh97g==
+"@electron/osx-sign@^1.0.5":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@electron/osx-sign/-/osx-sign-1.0.5.tgz#0af7149f2fce44d1a8215660fd25a9fb610454d8"
+  integrity sha512-k9ZzUQtamSoweGQDV2jILiRIHUu7lYlJ3c6IEmjv1hC17rclE+eb9U+f6UFlOOETo0JzY1HNlXy4YOlCvl+Lww==
   dependencies:
     compare-version "^0.1.2"
     debug "^4.3.4"


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron/electron-packager/blob/main/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

This PR bumps osx-sign to use 1.0.5 as a min version, to fix an issue with signing entitlements.

