### PR TITLE
ci: bump Node.js version for workflows

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -17,10 +17,10 @@ jobs:
           repository: electron/electron-quick-start
           ref: refs/heads/main
           path: electron-quick-start
-      - name: Use Node.js 14.x
+      - name: Setup Node.js
         uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # tag: v3.8.1
         with:
-          node-version: 14.x
+          node-version: lts/*
       - name: Replace electron with electron-nightly
         run: |
           cd electron-quick-start

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,7 +20,7 @@ jobs:
         run: git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
       - uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d  # tag: v3.8.1
         with:
-          node-version: 14.x
+          node-version: lts/*
       - run: npm install --engine-strict --no-lockfile
       - run: npm run docs:build
       - uses: dsanders11/github-action-gh-pages@6837fa66857ff3234e3ea5bcf709c86767ae3ce1


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [x] I have read the [contribution documentation](https://github.com/electron/electron-packager/blob/main/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.

**Summarize your changes:**

Get off of Node.js 14 since that's EOL and just use the current LTS to avoid the upgrade treadmill for these workflows, as it's low risk.