### PR TITLE
ci: use yarn in workflows

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -24,13 +24,13 @@ jobs:
       - name: Replace electron with electron-nightly
         run: |
           cd electron-quick-start
-          npm uninstall --save-dev electron
-          npm install --save-dev electron-nightly@latest
+          yarn remove electron
+          yarn add --dev electron-nightly@latest
         shell: bash
       - name: Install Electron Packager
         run: |
           cd electron-quick-start
-          npm install --save-dev electron-packager@electron/electron-packager
+          yarn add --dev electron-packager@electron/electron-packager
         shell: bash
       - name: Package
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,8 +21,8 @@ jobs:
       - uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d  # tag: v3.8.1
         with:
           node-version: lts/*
-      - run: npm install --engine-strict --no-lockfile
-      - run: npm run docs:build
+      - run: yarn install --frozen-lockfile
+      - run: yarn run docs:build
       - uses: dsanders11/github-action-gh-pages@6837fa66857ff3234e3ea5bcf709c86767ae3ce1
         with:
           defaultBranch: main


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [x] I have read the [contribution documentation](https://github.com/electron/electron-packager/blob/main/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.

**Summarize your changes:**

Follow-up to #1569, which apparently broke the publish docs workflow. This repo has a `yarn.lock` but the workflows were still using `npm` commands, and after bumping the Node.js version apparently those `npm` commands were modifying `yarn.lock` leading to an error. 🤔 So switch to using `yarn` commands.