### PR TITLE
ci: use npm in canary workflow

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -24,13 +24,13 @@ jobs:
       - name: Replace electron with electron-nightly
         run: |
           cd electron-quick-start
-          yarn remove electron
-          yarn add --dev electron-nightly@latest
+          npm uninstall --save-dev electron
+          npm install --save-dev electron-nightly@latest
         shell: bash
       - name: Install Electron Packager
         run: |
           cd electron-quick-start
-          yarn add --dev electron-packager@electron/electron-packager
+          npm install --save-dev electron-packager@electron/electron-packager
         shell: bash
       - name: Package
         run: |


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [x] I have read the [contribution documentation](https://github.com/electron/electron-packager/blob/main/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.

**Summarize your changes:**

Partially reverts #1570, the canary build needs to use `npm` when running commands in the checkout of `electron/electron-quick-start`.