### PR TITLE
feat: Add `osxSign.continueOnError` option

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,10 @@
 
 [Unreleased]: https://github.com/electron/electron-packager/compare/v17.1.2...main
 
+### Changed
+
+* Added `osxSign.continueOnError` option. Setting it to `false` will fail the build if there was an error signing the app instead of the default behavior of printing a warning. (#1579)
+
 ## [17.1.2] - 2023-08-18
 
 [17.1.2]: https://github.com/electron/electron-packager/compare/v17.1.1...v17.1.2

--- a/src/mac.js
+++ b/src/mac.js
@@ -351,7 +351,11 @@ class MacApp extends App {
         await signApp(signOpts)
       } catch (err) {
         // Although not signed successfully, the application is packed.
-        common.warning(`Code sign failed; please retry manually. ${err}`, this.opts.quiet)
+        if (signOpts.continueOnError) {
+          common.warning(`Code sign failed; please retry manually. ${err}`, this.opts.quiet)
+        } else {
+          throw err
+        }
       }
     }
   }
@@ -416,6 +420,11 @@ function createSignOpts (properties, platform, app, version, quiet) {
   // autodiscovery. Otherwise, provide signing certificate info.
   if (signOpts.identity === true) {
     signOpts.identity = null
+  }
+
+  // Default to `continueOnError: true` since this was the default behavior before this option was added
+  if (signOpts.continueOnError !== false) {
+    signOpts.continueOnError = true
   }
 
   return signOpts


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [x] I have read the [contribution documentation](https://github.com/electron/electron-packager/blob/main/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Currently there is no way to know that signing on osx failed other than reading the output. This adds an option `continueOnError` (defaults to current behavior, `true`) one can set to fail the build if there was an error while signing the app.