### PR TITLE
fix: Create tmp directory without using app name

### DIFF
--- a/src/platform.js
+++ b/src/platform.js
@@ -62,12 +62,9 @@ class App {
       return common.generateFinalPath(this.opts)
     } else {
       if (!this.cachedStagingPath) {
-        const parentDir = path.join(
-          common.baseTempDir(this.opts),
-          `${this.opts.platform}-${this.opts.arch}`
-        )
-        fs.mkdirpSync(parentDir)
-        this.cachedStagingPath = fs.mkdtempSync(path.join(parentDir, `${common.generateFinalBasename(this.opts)}-`))
+        const baseTempDir = common.baseTempDir(this.opts)
+        fs.mkdirpSync(baseTempDir)
+        this.cachedStagingPath = fs.mkdtempSync(path.resolve(baseTempDir, 'tmp-'))
       }
       return this.cachedStagingPath
     }


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [x] I have read the [contribution documentation](https://github.com/electron/electron-packager/blob/main/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:** Fix: Don't use app name when creating temporary directories, ensuring that npm scripts expecting paths without spaces will work fine.