### PR TITLE
chore!: remove support for the legacy notarization tool

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -10,17 +10,11 @@
 
 import { CreateOptions as AsarOptions } from '@electron/asar';
 import { ElectronDownloadRequestOptions as ElectronDownloadOptions } from '@electron/get';
-import {
-  LegacyNotarizeCredentials,
-  NotaryToolCredentials,
-  TransporterOptions
-} from '@electron/notarize/lib/types';
+import { NotaryToolCredentials } from '@electron/notarize/lib/types';
 import { SignOptions } from '@electron/osx-sign/dist/esm/types';
 import type { makeUniversalApp } from '@electron/universal';
 
 type MakeUniversalOpts = Parameters<typeof makeUniversalApp>[0]
-
-type NotarizeLegacyOptions = LegacyNotarizeCredentials & TransporterOptions;
 
 /**
  * Bundles Electron-based application source code with a renamed/customized Electron executable and
@@ -129,12 +123,6 @@ declare namespace electronPackager {
 
   /** See the documentation for [`@electron/osx-sign`](https://npm.im/@electron/osx-sign#opts) for details. */
   type OsxSignOptions = Omit<SignOptions, 'app' | 'binaries' | 'platform' | 'version'>;
-
-  /**
-   * See the documentation for [`@electron/notarize`](https://npm.im/@electron/notarize#method-notarizeopts-promisevoid)
-   * for details.
-   */
-  type OsxNotarizeOptions = { tool: 'notarytool' } & NotaryToolCredentials;
 
   /**
    * See the documentation for [`@electron/universal`](https://github.com/electron/universal)
@@ -476,7 +464,7 @@ declare namespace electronPackager {
      *
      * @category macOS
      */
-    osxNotarize?: OsxNotarizeOptions;
+    osxNotarize?: NotaryToolCredentials;
     /**
      * If present, signs macOS target apps when the host platform is macOS and Xcode is installed.
      * When the value is `true`, pass default configuration to the signing module. See

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -134,9 +134,7 @@ declare namespace electronPackager {
    * See the documentation for [`@electron/notarize`](https://npm.im/@electron/notarize#method-notarizeopts-promisevoid)
    * for details.
    */
-  type OsxNotarizeOptions =
-    | ({ tool?: 'legacy' } & NotarizeLegacyOptions)
-    | ({ tool: 'notarytool' } & NotaryToolCredentials);
+  type OsxNotarizeOptions = { tool: 'notarytool' } & NotaryToolCredentials;
 
   /**
    * See the documentation for [`@electron/universal`](https://github.com/electron/universal)

--- a/src/mac.js
+++ b/src/mac.js
@@ -432,11 +432,8 @@ function createSignOpts (properties, platform, app, version, quiet) {
 
 function createNotarizeOpts (properties, appBundleId, appPath, quiet) {
   // osxNotarize options are handed off to the @electron/notarize module, but with a few
-  // additions from the main options. The user may think they can pass bundle ID or appPath,
-  // but they will be ignored.
-  if (properties.tool !== 'notarytool') {
-    common.subOptionWarning(properties, 'osxNotarize', 'appBundleId', appBundleId, quiet)
-  }
+  // additions from the main options. The user may think they can pass appPath,
+  // but it will be ignored.
   common.subOptionWarning(properties, 'osxNotarize', 'appPath', appPath, quiet)
   return properties
 }

--- a/test/darwin.js
+++ b/test/darwin.js
@@ -298,16 +298,10 @@ if (!(process.env.CI && process.platform === 'win32')) {
     t.deepEqual(obj.CFBundleURLTypes, expected, 'CFBundleURLTypes did not contain specified protocol schemes and names')
   }))
 
-  test('osxNotarize: appBundleId can be overwritten if tool = notarytool', t => {
-    const args = { appleId: '1', appleIdPassword: '2', appBundleId: 'overwritten', tool: 'notarytool' }
+  test('osxNotarize: appBundleId can be overwritten', t => {
+    const args = { appleId: '1', appleIdPassword: '2', appBundleId: 'overwritten' }
     const notarizeOpts = mac.createNotarizeOpts(args, 'original', 'appPath', true)
     t.is(notarizeOpts.appBundleId, 'overwritten', 'appBundleId is taken from user-supplied options')
-  })
-
-  test('osxNotarize: appBundleId not overwritten', t => {
-    const args = { appleId: '1', appleIdPassword: '2', appBundleId: 'no' }
-    const notarizeOpts = mac.createNotarizeOpts(args, 'yes', 'appPath', true)
-    t.is(notarizeOpts.appBundleId, 'yes', 'appBundleId is taken from arguments')
   })
 
   test('osxNotarize: appPath not overwritten', t => {

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -191,6 +191,7 @@ await packager({
   osxNotarize: {
     appleId: 'My ID',
     appleIdPassword: 'Bad Password',
+    teamId: 'My Team ID',
   },
   osxSign: {
     identity: 'myidentity',


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

* [x] I have read the [contribution documentation](https://github.com/electron/electron-packager/blob/main/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

BREAKING CHANGE: remove support for the `tool` option in `osxNotarize`, meaning `notaryTool` will always be used and users will no longer be able to provide `tool: 'legacy'` (see https://github.com/electron/notarize/pull/141). This also removes the `NotarizeLegacyOptions` and `OsxNotarizeOptions` types because they're no longer necessary.